### PR TITLE
feat(statusline): add off-peak promotion indicators

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ The Anthropic usage API (`/api/oauth/usage`) has a very low rate limit — rough
 | 🟢/🟡/🟠/🔴 7d-sonnet | Per-model 7-day Sonnet quota (opt-in via `--per-model-quota`) |
 | 🟢/🟡/🟠/🔴 7d-cowork | Per-model 7-day cowork quota (opt-in via `--per-model-quota`) |
 | 🟢/🟡/🟠/🔴 7d-oauth | Per-model 7-day OAuth apps quota (opt-in via `--per-model-quota`) |
-| 🌈 Off-peak 5h | Shown next to 5h quota during active promotions when off-peak (doubled limit) |
-| ⏸ Off-peak 7d | Shown next to 7d quota during active promotions when off-peak (usage not counted) |
+| 🌈 Off-peak 5h | Shown next to 5h quota when promotional off-peak benefits are active |
+| ⏸ Off-peak 7d | Shown next to 7d quota when promotional off-peak benefits are active |
 | 💳 Credits | Monthly extra credit usage (only shown when active) |
 
 Quota indicators compare your usage rate against elapsed time to warn about hitting limits:

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ The Anthropic usage API (`/api/oauth/usage`) has a very low rate limit — rough
 | 🟢/🟡/🟠/🔴 7d-sonnet | Per-model 7-day Sonnet quota (opt-in via `--per-model-quota`) |
 | 🟢/🟡/🟠/🔴 7d-cowork | Per-model 7-day cowork quota (opt-in via `--per-model-quota`) |
 | 🟢/🟡/🟠/🔴 7d-oauth | Per-model 7-day OAuth apps quota (opt-in via `--per-model-quota`) |
+| 🌈 Off-peak 5h | Shown next to 5h quota during active promotions when off-peak (doubled limit) |
+| ⏸ Off-peak 7d | Shown next to 7d quota during active promotions when off-peak (usage not counted) |
 | 💳 Credits | Monthly extra credit usage (only shown when active) |
 
 Quota indicators compare your usage rate against elapsed time to warn about hitting limits:
@@ -97,6 +99,7 @@ compactions = true
 quota = true
 per_model_quota = false
 credits = true
+offpeak = true
 
 [cache]
 usage_ttl = "10m"
@@ -114,7 +117,7 @@ claudeline --no-cost --no-status
 claudeline --config /path/to/config.toml
 ```
 
-Available flags: `--no-model`, `--no-cost`, `--no-status`, `--no-context`, `--no-compactions`, `--no-quota`, `--per-model-quota`, `--no-credits`.
+Available flags: `--no-model`, `--no-cost`, `--no-status`, `--no-context`, `--no-compactions`, `--no-quota`, `--per-model-quota`, `--no-credits`, `--no-offpeak`.
 
 ## License
 

--- a/cmd/claudeline/main.go
+++ b/cmd/claudeline/main.go
@@ -303,7 +303,7 @@ func promoSuffix(label string, promo promotion.Status) string {
 	}
 
 	switch {
-	case label == "5h":
+	case label == "5h" || strings.HasPrefix(label, "5h-"):
 		return promo.FiveHour
 	case label == "7d" || strings.HasPrefix(label, "7d-"):
 		return promo.SevenDay

--- a/cmd/claudeline/main.go
+++ b/cmd/claudeline/main.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/lexfrei/claudeline/internal/config"
 	"github.com/lexfrei/claudeline/internal/fmtutil"
+	"github.com/lexfrei/claudeline/internal/promotion"
 	"github.com/lexfrei/claudeline/internal/status"
 	"github.com/lexfrei/claudeline/internal/usage"
 )
@@ -86,6 +87,7 @@ func newRootCmd() *cobra.Command {
 	flags.Bool("no-quota", false, "disable quota segment")
 	flags.Bool("per-model-quota", false, "enable per-model quota segments (opus, sonnet, etc.)")
 	flags.Bool("no-credits", false, "disable credits segment")
+	flags.Bool("no-offpeak", false, "disable off-peak promotion indicators")
 
 	return rootCmd
 }
@@ -121,6 +123,10 @@ func applyFlagOverrides(cmd *cobra.Command, cfg *config.Config) {
 
 	if flagSet(cmd, "no-credits") {
 		cfg.Segments.Credits = false
+	}
+
+	if flagSet(cmd, "no-offpeak") {
+		cfg.Segments.OffPeak = false
 	}
 }
 
@@ -180,7 +186,7 @@ func buildStatusline(raw []byte, cfg *config.Config) string {
 	return fmtutil.JoinPipe(segments)
 }
 
-func appendStaleQuotaSegments(segments []string, perModel bool) []string {
+func appendStaleQuotaSegments(segments []string, perModel bool, promo promotion.Status) []string {
 	lastGood := usage.FetchLastGood()
 	if lastGood == nil {
 		return append(segments, "⏳ 7d: ?% (?d)", "⏳ 5h: ?% (?h)")
@@ -207,25 +213,25 @@ func appendStaleQuotaSegments(segments []string, perModel bool) []string {
 
 	for _, w := range windows {
 		if w.win != nil {
-			segments = append(segments, usage.FormatStaleQuotaWindow(w.win, w.label))
+			segments = append(segments, usage.FormatStaleQuotaWindow(w.win, w.label)+promoSuffix(w.label, promo))
 		}
 	}
 
 	return segments
 }
 
-func appendRateLimitSegments(segments []string, cfg *config.Config) []string {
+func appendRateLimitSegments(segments []string, cfg *config.Config, promo promotion.Status) []string {
 	lastGood := usage.FetchLastGood()
 	segments = append(segments, usage.FormatRateLimitSegment(usage.FindExhaustedWindow(lastGood, cfg.Segments.PerModelQuota)))
 
 	if cfg.Segments.Quota {
-		segments = appendStaleQuotaSegments(segments, cfg.Segments.PerModelQuota)
+		segments = appendStaleQuotaSegments(segments, cfg.Segments.PerModelQuota, promo)
 	}
 
 	return segments
 }
 
-func appendQuotaWindows(segments []string, data *usage.Data, perModel bool) []string {
+func appendQuotaWindows(segments []string, data *usage.Data, perModel bool, promo promotion.Status) []string {
 	type labeledWindow struct {
 		win   *usage.QuotaWindow
 		label string
@@ -247,7 +253,7 @@ func appendQuotaWindows(segments []string, data *usage.Data, perModel bool) []st
 
 	for _, w := range windows {
 		if w.win != nil {
-			segments = append(segments, usage.FormatQuotaWindow(w.win, w.label))
+			segments = append(segments, usage.FormatQuotaWindow(w.win, w.label)+promoSuffix(w.label, promo))
 		}
 	}
 
@@ -255,10 +261,15 @@ func appendQuotaWindows(segments []string, data *usage.Data, perModel bool) []st
 }
 
 func appendUsageSegments(segments []string, cfg *config.Config) []string {
+	var promo promotion.Status
+	if cfg.Segments.OffPeak {
+		promo = promotion.Current()
+	}
+
 	usageData, err := usage.Fetch()
 	if err != nil {
 		if cfg.Segments.Quota {
-			segments = appendStaleQuotaSegments(segments, cfg.Segments.PerModelQuota)
+			segments = appendStaleQuotaSegments(segments, cfg.Segments.PerModelQuota, promo)
 		}
 
 		return segments
@@ -268,13 +279,13 @@ func appendUsageSegments(segments []string, cfg *config.Config) []string {
 	case "":
 		// no error, continue
 	case "rate_limit_error":
-		return appendRateLimitSegments(segments, cfg)
+		return appendRateLimitSegments(segments, cfg, promo)
 	default:
 		return append(segments, "⚠️ /login needed")
 	}
 
 	if cfg.Segments.Quota {
-		segments = appendQuotaWindows(segments, usageData, cfg.Segments.PerModelQuota)
+		segments = appendQuotaWindows(segments, usageData, cfg.Segments.PerModelQuota, promo)
 	}
 
 	if cfg.Segments.Credits && usageData.Extra != nil && usageData.Extra.UsedCredits > 0 {
@@ -283,4 +294,19 @@ func appendUsageSegments(segments []string, cfg *config.Config) []string {
 	}
 
 	return segments
+}
+
+func promoSuffix(label string, promo promotion.Status) string {
+	if !promo.Active {
+		return ""
+	}
+
+	switch label {
+	case "5h":
+		return promo.FiveHour
+	case "7d":
+		return promo.SevenDay
+	default:
+		return ""
+	}
 }

--- a/cmd/claudeline/main.go
+++ b/cmd/claudeline/main.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -301,10 +302,10 @@ func promoSuffix(label string, promo promotion.Status) string {
 		return ""
 	}
 
-	switch label {
-	case "5h":
+	switch {
+	case label == "5h":
 		return promo.FiveHour
-	case "7d":
+	case label == "7d" || strings.HasPrefix(label, "7d-"):
 		return promo.SevenDay
 	default:
 		return ""

--- a/cmd/claudeline/main_test.go
+++ b/cmd/claudeline/main_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/lexfrei/claudeline/internal/config"
 	"github.com/lexfrei/claudeline/internal/httpclient"
 	"github.com/lexfrei/claudeline/internal/keychain"
+	"github.com/lexfrei/claudeline/internal/promotion"
 	"github.com/lexfrei/claudeline/internal/status"
 	"github.com/lexfrei/claudeline/internal/usage"
 )
@@ -530,5 +531,94 @@ func TestFlagSetUnknownFlag(t *testing.T) {
 
 	if flagSet(cmd, "nonexistent-flag") {
 		t.Error("expected false for unknown flag")
+	}
+}
+
+func TestPromoSuffix(t *testing.T) {
+	t.Parallel()
+
+	active := promotion.Status{
+		Active:   true,
+		FiveHour: " 🌈",
+		SevenDay: " ⏸",
+	}
+	inactive := promotion.Status{}
+
+	tests := []struct {
+		name  string
+		label string
+		promo promotion.Status
+		want  string
+	}{
+		{"5h active", "5h", active, " 🌈"},
+		{"7d active", "7d", active, " ⏸"},
+		{"7d-opus active", "7d-opus", active, " ⏸"},
+		{"7d-sonnet active", "7d-sonnet", active, " ⏸"},
+		{"7d-cowork active", "7d-cowork", active, " ⏸"},
+		{"7d-oauth active", "7d-oauth", active, " ⏸"},
+		{"unknown label active", "credits", active, ""},
+		{"5h inactive", "5h", inactive, ""},
+		{"7d inactive", "7d", inactive, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := promoSuffix(tt.label, tt.promo)
+			if got != tt.want {
+				t.Errorf("promoSuffix(%q) = %q, want %q", tt.label, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAppendUsageSegmentsOffPeak(t *testing.T) {
+	cleanup := setupTestEnv(t)
+	defer cleanup()
+
+	// Set NowFn to off-peak time during March 2026 promo.
+	origNow := promotion.NowFn
+
+	defer func() { promotion.NowFn = origNow }()
+
+	// March 16 2026 Monday 20:00 EDT = March 17 00:00 UTC (off-peak).
+	promotion.NowFn = func() time.Time {
+		return time.Date(2026, 3, 17, 0, 0, 0, 0, time.UTC)
+	}
+
+	resetsAt := time.Now().Add(3 * time.Hour).UTC().Format(time.RFC3339)
+
+	keychain.GetFn = func() (string, error) { return testToken, nil }
+	usage.HTTPGetFn = func(_ string, _ map[string]string, _ time.Duration) (*httpclient.Response, error) {
+		return &httpclient.Response{
+			StatusCode: http.StatusOK,
+			Body: []byte(`{
+				"five_hour": {"utilization": 30, "resets_at": "` + resetsAt + `"},
+				"seven_day": {"utilization": 45, "resets_at": "` + resetsAt + `"}
+			}`),
+		}, nil
+	}
+
+	segments := appendUsageSegments(nil, defaultCfg())
+	joined := strings.Join(segments, " | ")
+
+	if !strings.Contains(joined, "🌈") {
+		t.Errorf("expected rainbow indicator for 5h off-peak, got %q", joined)
+	}
+
+	if !strings.Contains(joined, "⏸") {
+		t.Errorf("expected pause indicator for 7d off-peak, got %q", joined)
+	}
+
+	// Verify indicators are absent when offpeak is disabled.
+	cfg := defaultCfg()
+	cfg.Segments.OffPeak = false
+
+	segmentsDisabled := appendUsageSegments(nil, cfg)
+	joinedDisabled := strings.Join(segmentsDisabled, " | ")
+
+	if strings.Contains(joinedDisabled, "🌈") || strings.Contains(joinedDisabled, "⏸") {
+		t.Errorf("expected no off-peak indicators when disabled, got %q", joinedDisabled)
 	}
 }

--- a/cmd/claudeline/main_test.go
+++ b/cmd/claudeline/main_test.go
@@ -475,9 +475,9 @@ usage_ttl = "30s"
 
 func TestApplyFlagOverrides(t *testing.T) {
 	cmd := newRootCmd()
-	cmd.SetArgs([]string{"--no-model", "--no-quota", "--no-credits", "--per-model-quota"})
+	cmd.SetArgs([]string{"--no-model", "--no-quota", "--no-credits", "--per-model-quota", "--no-offpeak"})
 
-	parseErr := cmd.ParseFlags([]string{"--no-model", "--no-quota", "--no-credits", "--per-model-quota"})
+	parseErr := cmd.ParseFlags([]string{"--no-model", "--no-quota", "--no-credits", "--per-model-quota", "--no-offpeak"})
 	if parseErr != nil {
 		t.Fatal(parseErr)
 	}
@@ -503,6 +503,10 @@ func TestApplyFlagOverrides(t *testing.T) {
 
 	if !cfg.Segments.Cost {
 		t.Error("expected cost still enabled")
+	}
+
+	if cfg.Segments.OffPeak {
+		t.Error("expected offpeak disabled by flag")
 	}
 }
 

--- a/cmd/claudeline/main_test.go
+++ b/cmd/claudeline/main_test.go
@@ -556,6 +556,7 @@ func TestPromoSuffix(t *testing.T) {
 		{"7d-sonnet active", "7d-sonnet", active, " ⏸"},
 		{"7d-cowork active", "7d-cowork", active, " ⏸"},
 		{"7d-oauth active", "7d-oauth", active, " ⏸"},
+		{"5h-opus hypothetical", "5h-opus", active, " 🌈"},
 		{"unknown label active", "credits", active, ""},
 		{"5h inactive", "5h", inactive, ""},
 		{"7d inactive", "7d", inactive, ""},

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,6 +22,7 @@ type Segments struct {
 	Quota         bool `mapstructure:"quota"`
 	PerModelQuota bool `mapstructure:"per_model_quota"`
 	Credits       bool `mapstructure:"credits"`
+	OffPeak       bool `mapstructure:"offpeak"`
 }
 
 // Cache controls cache TTL durations.
@@ -47,6 +48,7 @@ func Defaults() Config {
 			Compactions: true,
 			Quota:       true,
 			Credits:     true,
+			OffPeak:     true,
 		},
 		Cache: Cache{
 			UsageTTL:  defaultUsageTTL,
@@ -89,6 +91,7 @@ func setViperDefaults(viperInstance *viper.Viper) {
 	viperInstance.SetDefault("segments.quota", true)
 	viperInstance.SetDefault("segments.per_model_quota", false)
 	viperInstance.SetDefault("segments.credits", true)
+	viperInstance.SetDefault("segments.offpeak", true)
 	viperInstance.SetDefault("cache.usage_ttl", defaultUsageTTL)
 	viperInstance.SetDefault("cache.status_ttl", defaultStatusTTL)
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -40,6 +40,10 @@ func TestDefaults(t *testing.T) {
 		t.Error("expected credits segment enabled by default")
 	}
 
+	if !cfg.Segments.OffPeak {
+		t.Error("expected offpeak segment enabled by default")
+	}
+
 	if cfg.Cache.UsageTTL != 10*time.Minute {
 		t.Errorf("expected usage TTL 60s, got %v", cfg.Cache.UsageTTL)
 	}
@@ -118,6 +122,7 @@ context = false
 compactions = false
 quota = false
 credits = false
+offpeak = false
 
 [cache]
 usage_ttl = "120s"
@@ -132,7 +137,8 @@ status_ttl = "30s"
 	cfg := Load(configPath)
 
 	if cfg.Segments.Model || cfg.Segments.Cost || cfg.Segments.Status ||
-		cfg.Segments.Context || cfg.Segments.Compactions || cfg.Segments.Quota || cfg.Segments.Credits {
+		cfg.Segments.Context || cfg.Segments.Compactions || cfg.Segments.Quota ||
+		cfg.Segments.Credits || cfg.Segments.OffPeak {
 		t.Error("expected all segments disabled")
 	}
 

--- a/internal/promotion/promotion.go
+++ b/internal/promotion/promotion.go
@@ -1,0 +1,69 @@
+// Package promotion provides client-side detection of Anthropic usage promotions.
+package promotion
+
+import (
+	"time"
+
+	_ "time/tzdata" // Embed timezone database for portability.
+)
+
+// NowFn is the time source, replaceable in tests.
+var NowFn = time.Now
+
+// PeakSchedule defines when peak hours apply (limits NOT doubled).
+type PeakSchedule struct {
+	StartHour int            // inclusive, 0-23
+	EndHour   int            // exclusive, 0-23
+	Weekdays  bool           // true = Mon-Fri only (weekends always off-peak)
+	Location  *time.Location // timezone for hour evaluation
+}
+
+// Promotion defines a time-limited usage promotion.
+type Promotion struct {
+	Name  string
+	Start time.Time // inclusive (UTC)
+	End   time.Time // exclusive (UTC)
+	Peak  PeakSchedule
+}
+
+// Status holds the off-peak indicators to append to quota labels.
+type Status struct {
+	Active   bool
+	FiveHour string // " 🌈" or ""
+	SevenDay string // " ⏸" or ""
+}
+
+// Current checks all known promotions and returns the current off-peak status.
+func Current() Status {
+	now := NowFn()
+
+	for idx := range knownPromotions {
+		if isOffPeak(now, knownPromotions[idx]) {
+			return Status{
+				Active:   true,
+				FiveHour: " 🌈",
+				SevenDay: " ⏸",
+			}
+		}
+	}
+
+	return Status{}
+}
+
+func isOffPeak(now time.Time, promo Promotion) bool {
+	if now.Before(promo.Start) || !now.Before(promo.End) {
+		return false
+	}
+
+	local := now.In(promo.Peak.Location)
+
+	return !isPeakHour(local.Hour(), local.Weekday(), promo.Peak)
+}
+
+func isPeakHour(hour int, weekday time.Weekday, sched PeakSchedule) bool {
+	if sched.Weekdays && (weekday == time.Saturday || weekday == time.Sunday) {
+		return false
+	}
+
+	return hour >= sched.StartHour && hour < sched.EndHour
+}

--- a/internal/promotion/promotion.go
+++ b/internal/promotion/promotion.go
@@ -34,6 +34,7 @@ type Status struct {
 }
 
 // Current checks all known promotions and returns the current off-peak status.
+// First matching promotion wins; overlapping promotions are not supported.
 func Current() Status {
 	now := NowFn()
 

--- a/internal/promotion/promotion_test.go
+++ b/internal/promotion/promotion_test.go
@@ -90,7 +90,7 @@ func TestIsOffPeak(t *testing.T) {
 	promo := Promotion{
 		Name:  "Test Promo",
 		Start: time.Date(2026, 3, 13, 0, 0, 0, 0, time.UTC),
-		End:   time.Date(2026, 3, 28, 8, 0, 0, 0, time.UTC),
+		End:   time.Date(2026, 3, 28, 6, 59, 0, 0, time.UTC),
 		Peak: PeakSchedule{
 			StartHour: 8,
 			EndHour:   14,
@@ -146,7 +146,7 @@ func TestIsOffPeak(t *testing.T) {
 		},
 		{
 			"promo end boundary exclusive",
-			time.Date(2026, 3, 28, 8, 0, 0, 0, time.UTC), // exactly at end
+			time.Date(2026, 3, 28, 6, 59, 0, 0, time.UTC), // exactly at end
 			false,
 		},
 	}
@@ -222,9 +222,62 @@ func TestIsOffPeakDST(t *testing.T) {
 	}
 }
 
-func TestCurrent(t *testing.T) {
+func TestIsOffPeakEndDatePDT(t *testing.T) {
 	t.Parallel()
 
+	// Verify the March 2026 promo end date in PDT context.
+	// March 27 23:59 PT (PDT, UTC-7) = March 28 06:59 UTC.
+	loc, err := time.LoadLocation("America/New_York")
+	if err != nil {
+		t.Skipf("tzdata not available: %v", err)
+	}
+
+	promo := Promotion{
+		Name:  "End Date Test",
+		Start: time.Date(2026, 3, 13, 0, 0, 0, 0, time.UTC),
+		End:   time.Date(2026, 3, 28, 6, 59, 0, 0, time.UTC),
+		Peak: PeakSchedule{
+			StartHour: 8,
+			EndHour:   14,
+			Weekdays:  true,
+			Location:  loc,
+		},
+	}
+
+	tests := []struct {
+		name string
+		now  time.Time
+		want bool
+	}{
+		{
+			"just before end March 28 00:00 PDT",
+			// March 28 00:00 PDT = March 28 07:00 UTC. But End is 06:59 UTC, so this is AFTER end.
+			time.Date(2026, 3, 28, 7, 0, 0, 0, time.UTC),
+			false,
+		},
+		{
+			"last minute before end",
+			// March 28 06:58 UTC is before 06:59 UTC end.
+			time.Date(2026, 3, 28, 6, 58, 0, 0, time.UTC),
+			true, // Saturday off-peak
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := isOffPeak(tt.now, promo)
+			if got != tt.want {
+				t.Errorf("isOffPeak(%v) = %v, want %v", tt.now, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestCurrent and TestCurrentMarch2026Promo do NOT use t.Parallel on the parent
+// because they mutate the package-level NowFn. Subtests also run sequentially.
+func TestCurrent(t *testing.T) {
 	tests := []struct {
 		name       string
 		now        time.Time
@@ -241,38 +294,29 @@ func TestCurrent(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
 			origNow := NowFn
 
 			t.Cleanup(func() { NowFn = origNow })
 
 			NowFn = func() time.Time { return tt.now }
 
-			status := Current()
-			if status.Active != tt.wantActive {
-				t.Errorf("Active = %v, want %v", status.Active, tt.wantActive)
+			got := Current()
+			if got.Active != tt.wantActive {
+				t.Errorf("Active = %v, want %v", got.Active, tt.wantActive)
 			}
 
-			if status.FiveHour != tt.wantFiveH {
-				t.Errorf("FiveHour = %q, want %q", status.FiveHour, tt.wantFiveH)
+			if got.FiveHour != tt.wantFiveH {
+				t.Errorf("FiveHour = %q, want %q", got.FiveHour, tt.wantFiveH)
 			}
 
-			if status.SevenDay != tt.wantSevenD {
-				t.Errorf("SevenDay = %q, want %q", status.SevenDay, tt.wantSevenD)
+			if got.SevenDay != tt.wantSevenD {
+				t.Errorf("SevenDay = %q, want %q", got.SevenDay, tt.wantSevenD)
 			}
 		})
 	}
 }
 
 func TestCurrentMarch2026Promo(t *testing.T) {
-	t.Parallel()
-
-	loc, err := time.LoadLocation("America/New_York")
-	if err != nil {
-		t.Skipf("tzdata not available: %v", err)
-	}
-
 	tests := []struct {
 		name       string
 		now        time.Time
@@ -300,29 +344,25 @@ func TestCurrentMarch2026Promo(t *testing.T) {
 		},
 	}
 
-	_ = loc // DST handled by knownPromotions using real location.
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
 			origNow := NowFn
 
 			t.Cleanup(func() { NowFn = origNow })
 
 			NowFn = func() time.Time { return tt.now }
 
-			status := Current()
-			if status.Active != tt.wantActive {
-				t.Errorf("Active = %v, want %v", status.Active, tt.wantActive)
+			got := Current()
+			if got.Active != tt.wantActive {
+				t.Errorf("Active = %v, want %v", got.Active, tt.wantActive)
 			}
 
-			if status.FiveHour != tt.wantFiveH {
-				t.Errorf("FiveHour = %q, want %q", status.FiveHour, tt.wantFiveH)
+			if got.FiveHour != tt.wantFiveH {
+				t.Errorf("FiveHour = %q, want %q", got.FiveHour, tt.wantFiveH)
 			}
 
-			if status.SevenDay != tt.wantSevenD {
-				t.Errorf("SevenDay = %q, want %q", status.SevenDay, tt.wantSevenD)
+			if got.SevenDay != tt.wantSevenD {
+				t.Errorf("SevenDay = %q, want %q", got.SevenDay, tt.wantSevenD)
 			}
 		})
 	}

--- a/internal/promotion/promotion_test.go
+++ b/internal/promotion/promotion_test.go
@@ -1,0 +1,329 @@
+package promotion
+
+import (
+	"testing"
+	"time"
+)
+
+func TestIsPeakHour(t *testing.T) {
+	t.Parallel()
+
+	loc := time.FixedZone("ET", -5*3600)
+
+	sched := PeakSchedule{
+		StartHour: 8,
+		EndHour:   14,
+		Weekdays:  true,
+		Location:  loc,
+	}
+
+	tests := []struct {
+		name    string
+		hour    int
+		weekday time.Weekday
+		want    bool
+	}{
+		{"before peak", 7, time.Monday, false},
+		{"peak start boundary", 8, time.Monday, true},
+		{"mid peak", 10, time.Wednesday, true},
+		{"last peak hour", 13, time.Friday, true},
+		{"peak end boundary", 14, time.Monday, false},
+		{"after peak", 20, time.Tuesday, false},
+		{"midnight", 0, time.Thursday, false},
+		{"saturday peak hour", 10, time.Saturday, false},
+		{"sunday peak hour", 10, time.Sunday, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := isPeakHour(tt.hour, tt.weekday, sched)
+			if got != tt.want {
+				t.Errorf("isPeakHour(%d, %s) = %v, want %v", tt.hour, tt.weekday, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsPeakHourAllDays(t *testing.T) {
+	t.Parallel()
+
+	loc := time.FixedZone("ET", -5*3600)
+
+	sched := PeakSchedule{
+		StartHour: 8,
+		EndHour:   14,
+		Weekdays:  false,
+		Location:  loc,
+	}
+
+	tests := []struct {
+		name    string
+		hour    int
+		weekday time.Weekday
+		want    bool
+	}{
+		{"saturday peak hour all days", 10, time.Saturday, true},
+		{"sunday peak hour all days", 10, time.Sunday, true},
+		{"weekday peak hour all days", 10, time.Monday, true},
+		{"off peak all days", 20, time.Saturday, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := isPeakHour(tt.hour, tt.weekday, sched)
+			if got != tt.want {
+				t.Errorf("isPeakHour(%d, %s) = %v, want %v", tt.hour, tt.weekday, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsOffPeak(t *testing.T) {
+	t.Parallel()
+
+	loc := time.FixedZone("ET", -5*3600)
+
+	promo := Promotion{
+		Name:  "Test Promo",
+		Start: time.Date(2026, 3, 13, 0, 0, 0, 0, time.UTC),
+		End:   time.Date(2026, 3, 28, 8, 0, 0, 0, time.UTC),
+		Peak: PeakSchedule{
+			StartHour: 8,
+			EndHour:   14,
+			Weekdays:  true,
+			Location:  loc,
+		},
+	}
+
+	tests := []struct {
+		name string
+		now  time.Time
+		want bool
+	}{
+		{
+			"weekday off-peak evening",
+			time.Date(2026, 3, 16, 1, 0, 0, 0, time.UTC), // 20:00 ET Monday
+			true,
+		},
+		{
+			"weekday peak morning",
+			time.Date(2026, 3, 16, 15, 0, 0, 0, time.UTC), // 10:00 ET Monday
+			false,
+		},
+		{
+			"weekend always off-peak",
+			time.Date(2026, 3, 14, 15, 0, 0, 0, time.UTC), // 10:00 ET Saturday
+			true,
+		},
+		{
+			"before promo start",
+			time.Date(2026, 3, 12, 1, 0, 0, 0, time.UTC),
+			false,
+		},
+		{
+			"after promo end",
+			time.Date(2026, 3, 29, 1, 0, 0, 0, time.UTC),
+			false,
+		},
+		{
+			"peak start boundary",
+			time.Date(2026, 3, 17, 13, 0, 0, 0, time.UTC), // 08:00 ET Tuesday
+			false,
+		},
+		{
+			"peak end boundary",
+			time.Date(2026, 3, 17, 19, 0, 0, 0, time.UTC), // 14:00 ET Tuesday
+			true,
+		},
+		{
+			"promo start boundary inclusive",
+			time.Date(2026, 3, 13, 0, 0, 0, 0, time.UTC), // exactly at start, midnight UTC Friday
+			true,
+		},
+		{
+			"promo end boundary exclusive",
+			time.Date(2026, 3, 28, 8, 0, 0, 0, time.UTC), // exactly at end
+			false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := isOffPeak(tt.now, promo)
+			if got != tt.want {
+				t.Errorf("isOffPeak(%v) = %v, want %v", tt.now, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsOffPeakDST(t *testing.T) {
+	t.Parallel()
+
+	// Use real America/New_York for DST testing.
+	loc, err := time.LoadLocation("America/New_York")
+	if err != nil {
+		t.Skipf("tzdata not available: %v", err)
+	}
+
+	// DST spring forward: March 8, 2026 at 2:00 AM ET.
+	promo := Promotion{
+		Name:  "DST Test",
+		Start: time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC),
+		End:   time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC),
+		Peak: PeakSchedule{
+			StartHour: 8,
+			EndHour:   14,
+			Weekdays:  true,
+			Location:  loc,
+		},
+	}
+
+	tests := []struct {
+		name string
+		now  time.Time
+		want bool
+	}{
+		{
+			"before DST 10am EST Monday",
+			// March 2 2026 is Monday. 10:00 EST = 15:00 UTC.
+			time.Date(2026, 3, 2, 15, 0, 0, 0, time.UTC),
+			false, // peak
+		},
+		{
+			"after DST 10am EDT Monday",
+			// March 9 2026 is Monday. 10:00 EDT = 14:00 UTC.
+			time.Date(2026, 3, 9, 14, 0, 0, 0, time.UTC),
+			false, // peak
+		},
+		{
+			"after DST 20:00 EDT Monday",
+			// March 9 2026. 20:00 EDT = 00:00 UTC next day.
+			time.Date(2026, 3, 10, 0, 0, 0, 0, time.UTC),
+			true, // off-peak
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := isOffPeak(tt.now, promo)
+			if got != tt.want {
+				t.Errorf("isOffPeak(%v) = %v, want %v", tt.now, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCurrent(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		now        time.Time
+		wantActive bool
+		wantFiveH  string
+		wantSevenD string
+	}{
+		{
+			"no active promo",
+			time.Date(2020, 1, 1, 12, 0, 0, 0, time.UTC),
+			false, "", "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			origNow := NowFn
+
+			t.Cleanup(func() { NowFn = origNow })
+
+			NowFn = func() time.Time { return tt.now }
+
+			status := Current()
+			if status.Active != tt.wantActive {
+				t.Errorf("Active = %v, want %v", status.Active, tt.wantActive)
+			}
+
+			if status.FiveHour != tt.wantFiveH {
+				t.Errorf("FiveHour = %q, want %q", status.FiveHour, tt.wantFiveH)
+			}
+
+			if status.SevenDay != tt.wantSevenD {
+				t.Errorf("SevenDay = %q, want %q", status.SevenDay, tt.wantSevenD)
+			}
+		})
+	}
+}
+
+func TestCurrentMarch2026Promo(t *testing.T) {
+	t.Parallel()
+
+	loc, err := time.LoadLocation("America/New_York")
+	if err != nil {
+		t.Skipf("tzdata not available: %v", err)
+	}
+
+	tests := []struct {
+		name       string
+		now        time.Time
+		wantActive bool
+		wantFiveH  string
+		wantSevenD string
+	}{
+		{
+			"off-peak evening",
+			// March 16 2026 Monday 20:00 EDT = March 17 00:00 UTC.
+			time.Date(2026, 3, 17, 0, 0, 0, 0, time.UTC),
+			true, " 🌈", " ⏸",
+		},
+		{
+			"peak morning",
+			// March 16 2026 Monday 10:00 EDT = March 16 14:00 UTC.
+			time.Date(2026, 3, 16, 14, 0, 0, 0, time.UTC),
+			false, "", "",
+		},
+		{
+			"weekend",
+			// March 14 2026 Saturday 10:00 EDT.
+			time.Date(2026, 3, 14, 14, 0, 0, 0, time.UTC),
+			true, " 🌈", " ⏸",
+		},
+	}
+
+	_ = loc // DST handled by knownPromotions using real location.
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			origNow := NowFn
+
+			t.Cleanup(func() { NowFn = origNow })
+
+			NowFn = func() time.Time { return tt.now }
+
+			status := Current()
+			if status.Active != tt.wantActive {
+				t.Errorf("Active = %v, want %v", status.Active, tt.wantActive)
+			}
+
+			if status.FiveHour != tt.wantFiveH {
+				t.Errorf("FiveHour = %q, want %q", status.FiveHour, tt.wantFiveH)
+			}
+
+			if status.SevenDay != tt.wantSevenD {
+				t.Errorf("SevenDay = %q, want %q", status.SevenDay, tt.wantSevenD)
+			}
+		})
+	}
+}

--- a/internal/promotion/promotion_test.go
+++ b/internal/promotion/promotion_test.go
@@ -222,11 +222,11 @@ func TestIsOffPeakDST(t *testing.T) {
 	}
 }
 
-func TestIsOffPeakEndDatePDT(t *testing.T) {
+func TestIsOffPeakEndDateBoundary(t *testing.T) {
 	t.Parallel()
 
-	// Verify the March 2026 promo end date in PDT context.
-	// March 27 23:59 PT (PDT, UTC-7) = March 28 06:59 UTC.
+	// Verify the UTC end boundary derived from March 27 23:59 PDT (= March 28 06:59 UTC).
+	// Peak schedule location (ET) is irrelevant to end date check — End is stored in UTC.
 	loc, err := time.LoadLocation("America/New_York")
 	if err != nil {
 		t.Skipf("tzdata not available: %v", err)

--- a/internal/promotion/promotions.go
+++ b/internal/promotion/promotions.go
@@ -3,8 +3,8 @@ package promotion
 import "time"
 
 const (
-	peakStartMarch2026 = 8  // 8 AM ET.
-	peakEndMarch2026   = 14 // 2 PM ET.
+	peakStartMarch2026 = 8  // 8 AM ET (Eastern Time, as defined by Anthropic).
+	peakEndMarch2026   = 14 // 2 PM ET (Eastern Time, as defined by Anthropic).
 )
 
 // knownPromotions lists all Anthropic usage promotions.

--- a/internal/promotion/promotions.go
+++ b/internal/promotion/promotions.go
@@ -2,6 +2,11 @@ package promotion
 
 import "time"
 
+const (
+	peakStartMarch2026 = 8  // 8 AM ET.
+	peakEndMarch2026   = 14 // 2 PM ET.
+)
+
 // knownPromotions lists all Anthropic usage promotions.
 // Add new entries here and rebuild to support future promotions.
 var knownPromotions = []Promotion{
@@ -10,8 +15,8 @@ var knownPromotions = []Promotion{
 		Start: time.Date(2026, 3, 13, 0, 0, 0, 0, time.UTC),
 		End:   time.Date(2026, 3, 28, 8, 0, 0, 0, time.UTC), // March 27 23:59 PT
 		Peak: PeakSchedule{
-			StartHour: 8,
-			EndHour:   14,
+			StartHour: peakStartMarch2026,
+			EndHour:   peakEndMarch2026,
 			Weekdays:  true,
 			Location:  mustLoadLocation("America/New_York"),
 		},

--- a/internal/promotion/promotions.go
+++ b/internal/promotion/promotions.go
@@ -13,7 +13,7 @@ var knownPromotions = []Promotion{
 	{
 		Name:  "March 2026",
 		Start: time.Date(2026, 3, 13, 0, 0, 0, 0, time.UTC),
-		End:   time.Date(2026, 3, 28, 8, 0, 0, 0, time.UTC), // March 27 23:59 PT
+		End:   time.Date(2026, 3, 28, 6, 59, 0, 0, time.UTC), // March 27 23:59 PT (PDT, UTC-7)
 		Peak: PeakSchedule{
 			StartHour: peakStartMarch2026,
 			EndHour:   peakEndMarch2026,

--- a/internal/promotion/promotions.go
+++ b/internal/promotion/promotions.go
@@ -1,0 +1,28 @@
+package promotion
+
+import "time"
+
+// knownPromotions lists all Anthropic usage promotions.
+// Add new entries here and rebuild to support future promotions.
+var knownPromotions = []Promotion{
+	{
+		Name:  "March 2026",
+		Start: time.Date(2026, 3, 13, 0, 0, 0, 0, time.UTC),
+		End:   time.Date(2026, 3, 28, 8, 0, 0, 0, time.UTC), // March 27 23:59 PT
+		Peak: PeakSchedule{
+			StartHour: 8,
+			EndHour:   14,
+			Weekdays:  true,
+			Location:  mustLoadLocation("America/New_York"),
+		},
+	},
+}
+
+func mustLoadLocation(name string) *time.Location {
+	loc, err := time.LoadLocation(name)
+	if err != nil {
+		panic("promotion: failed to load timezone " + name + ": " + err.Error())
+	}
+
+	return loc
+}


### PR DESCRIPTION
## Summary

- Add client-side detection of Anthropic usage promotions (off-peak doubled limits)
- Show 🌈 next to 5h quota and ⏸ next to 7d quota during off-peak hours
- Promotions defined as constants with timezone-aware peak hour schedules
- New `--no-offpeak` flag and `offpeak` config toggle to disable indicators
- Includes March 2026 promotion definition (peak: 8AM-2PM ET weekdays)

## Details

The Anthropic API does not expose off-peak status. Detection is done client-side
by matching the current time against known promotion schedules baked into the binary.
Uses embedded tzdata for portable timezone evaluation including DST handling.

New package `internal/promotion/` with full test coverage including boundary cases,
DST transitions, and promotion period edges.

## Test plan

- [x] Unit tests for peak hour detection (boundary hours, weekday vs weekend)
- [x] Unit tests for off-peak detection (during/outside promo, peak/off-peak times)
- [x] DST transition tests (EST→EDT spring forward)
- [x] Integration tests via `TestCurrent` with `NowFn` injection
- [x] All existing tests pass
- [x] Zero linter errors