### PR TITLE
feat: worktree segment and refreshInterval docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,7 @@ Real-time statusline for [Claude Code](https://docs.anthropic.com/en/docs/claude
 ## Example output
 
 ```text
-🤖 Claude | 💰 $1.37 | 🟢 7d: 45% (4d 2h) | 🟢 5h: 12% (4h 23m)
-```
-
-```text
-🤖 Claude | 💰 $0.00 | ⚠️ degraded | 🧠 67% | 🔄 2 | 🟠 7d: 74% (1d 17h) | 🔴 5h: 91% (27m)
+🤖 Opus 4.6 | 🌿 feat-api | 🧠 67% | 🔄 2 | 🟡 7d: 42% (4d 2h) | 🔴 5h: 91% (27m)
 ```
 
 ## Segments
@@ -21,7 +17,8 @@ Real-time statusline for [Claude Code](https://docs.anthropic.com/en/docs/claude
 | Segment | Description |
 | --- | --- |
 | 🤖 Model | Active model name |
-| 💰 Cost | Cumulative session cost in USD |
+| 🌿 Worktree | Git worktree name when cwd is inside a linked worktree (Claude Code v2.1.97+) |
+| 💰 Cost | Cumulative session cost in USD (hidden by default for subscribers, see [Cost mode](#cost-mode)) |
 | ⚠️/🔶/🔴 Status | Anthropic platform status: ⚠️ degraded, 🔶 major outage, 🔴 critical (hidden when all clear) |
 | 🧠 Context | Context window usage percentage (color-coded) |
 | 🔄 Compactions | Number of context compactions in current session |
@@ -35,6 +32,16 @@ Quota indicators compare your usage rate against elapsed time to warn about hitt
 - 🟠 usage is significantly ahead of schedule
 - 🔴 on track to hit the limit before reset
 
+### Cost mode
+
+The cost segment has three modes:
+
+- `auto` (default) — hide for Claude.ai subscribers (who have rate limits), show for API users
+- `true` — always show
+- `false` — never show
+
+Set via `--cost auto|true|false` or `cost = "auto"` in config.
+
 ### Off-peak promotions
 
 During [Anthropic usage promotions](https://support.claude.com/en/articles/14063676-claude-march-2026-usage-promotion), off-peak hours provide boosted 5-hour limits. claudeline shows ⬆ next to the 5h quota segment when a promotion is active and you are in an off-peak window. The 7-day limit is unaffected — only bonus usage above the normal 5h cap is excluded from weekly counting.
@@ -43,7 +50,8 @@ Disable with `--no-offpeak` or `offpeak = false` in config.
 
 ## Requirements
 
-- Claude Code v2.1.80+ (provides `rate_limits` in statusline stdin)
+- Claude Code v2.1.82+ (provides `rate_limits` in statusline stdin)
+- Claude Code v2.1.97+ recommended (adds `workspace.git_worktree` and `refreshInterval`)
 
 ## Installation
 
@@ -77,6 +85,23 @@ Claude Code pipes session data as JSON to stdin. claudeline reads it and outputs
 
 Restart Claude Code after changing settings.
 
+### Keep quota timers ticking
+
+By default Claude Code re-runs the statusline command on each new assistant message, on permission mode changes, and on vim mode toggles. While the session is idle (for example waiting on background subagents), the command is not re-run and quota reset timers freeze on screen.
+
+Set `refreshInterval` in `~/.claude/settings.json` to also re-run the command on a fixed timer. This **adds** to event-driven updates, it does not replace them. Requires Claude Code v2.1.97+.
+
+```json
+{
+  "statusLine": {
+    "type": "command",
+    "command": "claudeline",
+    "padding": 0,
+    "refreshInterval": 5
+  }
+}
+```
+
 ## Configuration
 
 Optional config file at `~/.claudelinerc.toml`:
@@ -84,7 +109,8 @@ Optional config file at `~/.claudelinerc.toml`:
 ```toml
 [segments]
 model = true
-cost = true
+worktree = true
+cost = "auto"
 status = true
 context = true
 compactions = true
@@ -95,18 +121,20 @@ offpeak = true
 status_ttl = "15s"
 ```
 
-Set any segment to `false` to hide it.
+Set any segment to `false` to hide it (`cost` accepts `"auto"`, `"true"`, `"false"`).
+
+Run `claudeline validate --config ~/.claudelinerc.toml` to check your config for typos and invalid values.
 
 ### CLI flags
 
 Flags override config file settings:
 
 ```bash
-claudeline --no-cost --no-status
+claudeline --cost false --no-status
 claudeline --config /path/to/config.toml
 ```
 
-Available flags: `--no-model`, `--no-cost`, `--no-status`, `--no-context`, `--no-compactions`, `--no-quota`, `--no-offpeak`.
+Available flags: `--no-model`, `--no-worktree`, `--cost`, `--no-status`, `--no-context`, `--no-compactions`, `--no-quota`, `--no-offpeak`, `--mac-insecure`.
 
 ## Advanced: `--mac-insecure` mode
 

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ claudeline --cost false --no-status
 claudeline --config /path/to/config.toml
 ```
 
-Available flags: `--no-model`, `--no-worktree`, `--cost`, `--no-status`, `--no-context`, `--no-compactions`, `--no-quota`, `--no-offpeak`, `--mac-insecure`.
+Available flags: `--no-model`, `--no-worktree`, `--cost`, `--no-status`, `--no-context`, `--no-compactions`, `--no-quota`, `--no-offpeak`, `--mac-insecure`, `--per-model-quota`, `--no-credits`. The last two only take effect with `--mac-insecure`.
 
 ## Advanced: `--mac-insecure` mode
 

--- a/cmd/claudeline/main.go
+++ b/cmd/claudeline/main.go
@@ -34,6 +34,9 @@ type stdinData struct {
 	Model struct {
 		DisplayName string `json:"display_name"` //nolint:tagliatelle // External API format
 	} `json:"model"`
+	Workspace struct {
+		GitWorktree string `json:"git_worktree"` //nolint:tagliatelle // External API format
+	} `json:"workspace"`
 	Cost struct {
 		TotalCostUSD float64 `json:"total_cost_usd"` //nolint:tagliatelle // External API format
 	} `json:"cost"`
@@ -95,6 +98,7 @@ func newRootCmd() *cobra.Command {
 	flags := rootCmd.PersistentFlags()
 	flags.StringVar(&configPath, "config", defaultConfigPath(), "config file path")
 	flags.Bool("no-model", false, "disable model segment")
+	flags.Bool("no-worktree", false, "disable worktree segment")
 	flags.String("cost", "", "cost segment mode: auto (default), true, false")
 	flags.Bool("no-status", false, "disable status segment")
 	flags.Bool("no-context", false, "disable context segment")
@@ -135,6 +139,10 @@ func newValidateCmd(configPath *string) *cobra.Command {
 func applyFlagOverrides(cmd *cobra.Command, cfg *config.Config) {
 	if flagSet(cmd, "no-model") {
 		cfg.Segments.Model = false
+	}
+
+	if flagSet(cmd, "no-worktree") {
+		cfg.Segments.Worktree = false
 	}
 
 	if flagSet(cmd, "cost") {
@@ -199,6 +207,19 @@ func buildStatusline(raw []byte, cfg *config.Config) string {
 
 	var segments []string
 
+	segments = appendIdentitySegments(segments, &data, cfg)
+	segments = appendCostAndStatusSegments(segments, &data, cfg)
+	segments = appendContextSegments(segments, &data, cfg)
+
+	if cfg.Segments.Quota || cfg.Segments.Credits {
+		segments = appendUsageSegments(segments, &data, cfg)
+	}
+
+	return fmtutil.JoinPipe(segments)
+}
+
+// appendIdentitySegments adds model and worktree segments (who you are, where you are).
+func appendIdentitySegments(segments []string, data *stdinData, cfg *config.Config) []string {
 	if cfg.Segments.Model {
 		model := "Claude"
 		if data.Model.DisplayName != "" {
@@ -208,6 +229,15 @@ func buildStatusline(raw []byte, cfg *config.Config) string {
 		segments = append(segments, "🤖 "+model)
 	}
 
+	if cfg.Segments.Worktree && data.Workspace.GitWorktree != "" {
+		segments = append(segments, "🌿 "+data.Workspace.GitWorktree)
+	}
+
+	return segments
+}
+
+// appendCostAndStatusSegments adds cost and platform status segments.
+func appendCostAndStatusSegments(segments []string, data *stdinData, cfg *config.Config) []string {
 	if shouldShowCost(cfg.Segments.Cost, data.RateLimits.FiveHour != nil || data.RateLimits.SevenDay != nil) {
 		segments = append(segments, fmt.Sprintf("💰 $%.2f", data.Cost.TotalCostUSD))
 	}
@@ -218,6 +248,11 @@ func buildStatusline(raw []byte, cfg *config.Config) string {
 		}
 	}
 
+	return segments
+}
+
+// appendContextSegments adds context window and compaction segments.
+func appendContextSegments(segments []string, data *stdinData, cfg *config.Config) []string {
 	if cfg.Segments.Context && data.ContextWindow.UsedPercentage > 0 {
 		segments = append(segments, fmtutil.ContextSegment(data.ContextWindow.UsedPercentage))
 	}
@@ -228,11 +263,7 @@ func buildStatusline(raw []byte, cfg *config.Config) string {
 		}
 	}
 
-	if cfg.Segments.Quota || cfg.Segments.Credits {
-		segments = appendUsageSegments(segments, &data, cfg)
-	}
-
-	return fmtutil.JoinPipe(segments)
+	return segments
 }
 
 // shouldShowCost determines whether to display the cost segment.

--- a/cmd/claudeline/main_test.go
+++ b/cmd/claudeline/main_test.go
@@ -586,6 +586,7 @@ func TestBuildStatuslineAllDisabled(t *testing.T) {
 
 	cfg := defaultCfg()
 	cfg.Segments.Model = false
+	cfg.Segments.Worktree = false
 	cfg.Segments.Cost = config.CostOff
 	cfg.Segments.Status = false
 	cfg.Segments.Context = false
@@ -593,7 +594,11 @@ func TestBuildStatuslineAllDisabled(t *testing.T) {
 	cfg.Segments.Quota = false
 	cfg.Segments.Credits = false
 
-	got := buildStatusline([]byte(`{}`), cfg)
+	// Use real data for each segment so the disables must actually fire —
+	// an absent field would hide the segment regardless of the config toggle.
+	input := `{"model":{"display_name":"Opus 4.6"},"workspace":{"git_worktree":"feat-api"},"cost":{"total_cost_usd":1.5},"context_window":{"used_percentage":50}}`
+
+	got := buildStatusline([]byte(input), cfg)
 
 	if got != "" {
 		t.Errorf("expected empty output, got %q", got)

--- a/cmd/claudeline/main_test.go
+++ b/cmd/claudeline/main_test.go
@@ -169,6 +169,56 @@ func TestBuildStatuslineStdinPartialRateLimits(t *testing.T) {
 	}
 }
 
+func TestBuildStatuslineWithWorktree(t *testing.T) {
+	cleanup := setupTestEnv(t)
+	defer cleanup()
+
+	status.HTTPGetFn = failHTTP
+
+	input := `{"model":{"display_name":"Opus 4.6"},"workspace":{"git_worktree":"feat-api"}}`
+	got := buildStatusline([]byte(input), defaultCfg())
+
+	if !strings.Contains(got, "🌿 feat-api") {
+		t.Errorf("expected worktree segment, got %q", got)
+	}
+
+	// Worktree should appear right after model.
+	if !strings.Contains(got, "🤖 Opus 4.6 | 🌿 feat-api") {
+		t.Errorf("expected worktree right after model, got %q", got)
+	}
+}
+
+func TestBuildStatuslineNoWorktreeField(t *testing.T) {
+	cleanup := setupTestEnv(t)
+	defer cleanup()
+
+	status.HTTPGetFn = failHTTP
+
+	input := `{"model":{"display_name":"Opus 4.6"},"workspace":{}}`
+	got := buildStatusline([]byte(input), defaultCfg())
+
+	if strings.Contains(got, "🌿") {
+		t.Errorf("expected no worktree segment when field is empty, got %q", got)
+	}
+}
+
+func TestBuildStatuslineWorktreeDisabled(t *testing.T) {
+	cleanup := setupTestEnv(t)
+	defer cleanup()
+
+	status.HTTPGetFn = failHTTP
+
+	cfg := defaultCfg()
+	cfg.Segments.Worktree = false
+
+	input := `{"model":{"display_name":"Opus 4.6"},"workspace":{"git_worktree":"feat-api"}}`
+	got := buildStatusline([]byte(input), cfg)
+
+	if strings.Contains(got, "🌿") {
+		t.Errorf("expected no worktree when segment disabled, got %q", got)
+	}
+}
+
 func TestBuildStatuslineWithModel(t *testing.T) {
 	cleanup := setupTestEnv(t)
 	defer cleanup()
@@ -619,9 +669,9 @@ usage_ttl = "30s"
 
 func TestApplyFlagOverrides(t *testing.T) {
 	cmd := newRootCmd()
-	cmd.SetArgs([]string{"--no-model", "--no-quota", "--no-credits", "--per-model-quota", "--no-offpeak", "--mac-insecure"})
+	cmd.SetArgs([]string{"--no-model", "--no-worktree", "--no-quota", "--no-credits", "--per-model-quota", "--no-offpeak", "--mac-insecure"})
 
-	parseErr := cmd.ParseFlags([]string{"--no-model", "--no-quota", "--no-credits", "--per-model-quota", "--no-offpeak", "--mac-insecure"})
+	parseErr := cmd.ParseFlags([]string{"--no-model", "--no-worktree", "--no-quota", "--no-credits", "--per-model-quota", "--no-offpeak", "--mac-insecure"})
 	if parseErr != nil {
 		t.Fatal(parseErr)
 	}
@@ -631,6 +681,10 @@ func TestApplyFlagOverrides(t *testing.T) {
 
 	if cfg.Segments.Model {
 		t.Error("expected model disabled by flag")
+	}
+
+	if cfg.Segments.Worktree {
+		t.Error("expected worktree disabled by flag")
 	}
 
 	if cfg.Segments.Quota {

--- a/cmd/claudeline/main_test.go
+++ b/cmd/claudeline/main_test.go
@@ -95,6 +95,11 @@ func TestBuildStatuslineMinimal(t *testing.T) {
 	if strings.Contains(got, "⏳") || strings.Contains(got, "7d") || strings.Contains(got, "5h") {
 		t.Errorf("expected no quota segments without rate_limits in stdin, got %q", got)
 	}
+
+	// Empty stdin = no worktree segment even though the toggle is on by default.
+	if strings.Contains(got, "🌿") {
+		t.Errorf("expected no worktree without git_worktree in stdin, got %q", got)
+	}
 }
 
 func TestBuildStatuslineWithStdinRateLimits(t *testing.T) {
@@ -199,6 +204,27 @@ func TestBuildStatuslineNoWorktreeField(t *testing.T) {
 
 	if strings.Contains(got, "🌿") {
 		t.Errorf("expected no worktree segment when field is empty, got %q", got)
+	}
+}
+
+func TestBuildStatuslineWorktreeWithModelDisabled(t *testing.T) {
+	cleanup := setupTestEnv(t)
+	defer cleanup()
+
+	status.HTTPGetFn = failHTTP
+
+	cfg := defaultCfg()
+	cfg.Segments.Model = false
+
+	input := `{"workspace":{"git_worktree":"feat-api"}}`
+	got := buildStatusline([]byte(input), cfg)
+
+	if !strings.Contains(got, "🌿 feat-api") {
+		t.Errorf("expected worktree even when model disabled, got %q", got)
+	}
+
+	if strings.Contains(got, "🤖") {
+		t.Errorf("expected no model segment, got %q", got)
 	}
 }
 
@@ -624,13 +650,56 @@ func TestNewRootCmdWithFlags(t *testing.T) {
 	usage.HTTPGetFn = failHTTP
 
 	cmd := newRootCmd()
-	cmd.SetArgs([]string{"--no-model", "--cost", "false", "--config", "/nonexistent/config.toml"})
-	cmd.SetIn(strings.NewReader(`{}`))
+	cmd.SetArgs([]string{"--no-model", "--no-worktree", "--cost", "false", "--config", "/nonexistent/config.toml"})
+	cmd.SetIn(strings.NewReader(`{"workspace":{"git_worktree":"feat-api"}}`))
 
-	err := cmd.Execute()
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
+	captured := captureStdout(t, func() {
+		executeErr := cmd.Execute()
+		if executeErr != nil {
+			t.Errorf("unexpected error: %v", executeErr)
+		}
+	})
+
+	if strings.Contains(captured, "🌿") {
+		t.Errorf("--no-worktree should suppress worktree segment, got %q", captured)
 	}
+
+	if strings.Contains(captured, "🤖") {
+		t.Errorf("--no-model should suppress model segment, got %q", captured)
+	}
+}
+
+// captureStdout redirects os.Stdout for the duration of body and returns captured output.
+func captureStdout(t *testing.T, body func()) string {
+	t.Helper()
+
+	orig := os.Stdout
+
+	reader, writer, pipeErr := os.Pipe()
+	if pipeErr != nil {
+		t.Fatal(pipeErr)
+	}
+
+	os.Stdout = writer
+
+	done := make(chan string, 1)
+
+	go func() {
+		buf, readErr := io.ReadAll(reader)
+		if readErr != nil {
+			t.Errorf("readall: %v", readErr)
+		}
+
+		done <- string(buf)
+	}()
+
+	body()
+
+	writer.Close()
+
+	os.Stdout = orig
+
+	return <-done
 }
 
 func TestNewRootCmdWithConfigFile(t *testing.T) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -39,6 +39,7 @@ func NormalizeCostMode(raw string) string {
 // Segments controls which statusline segments are displayed.
 type Segments struct {
 	Model         bool   `mapstructure:"model"`
+	Worktree      bool   `mapstructure:"worktree"`
 	Cost          string `mapstructure:"cost"`
 	Status        bool   `mapstructure:"status"`
 	Context       bool   `mapstructure:"context"`
@@ -67,6 +68,7 @@ func Defaults() Config {
 	return Config{
 		Segments: Segments{
 			Model:       true,
+			Worktree:    true,
 			Cost:        CostAuto,
 			Status:      true,
 			Context:     true,
@@ -122,6 +124,7 @@ func Load(configPath string) Config {
 // knownKeys is the set of all valid configuration keys.
 var knownKeys = map[string]bool{
 	"segments.model":           true,
+	"segments.worktree":        true,
 	"segments.cost":            true,
 	"segments.status":          true,
 	"segments.context":         true,
@@ -187,6 +190,7 @@ func validateSegments(seg *Segments, v *viper.Viper) []string {
 		raw any
 	}{
 		{"segments.model", v.Get("segments.model")},
+		{"segments.worktree", v.Get("segments.worktree")},
 		{"segments.status", v.Get("segments.status")},
 		{"segments.context", v.Get("segments.context")},
 		{"segments.compactions", v.Get("segments.compactions")},
@@ -231,6 +235,7 @@ func validateCache(cache *Cache) []string {
 
 func setViperDefaults(viperInstance *viper.Viper) {
 	viperInstance.SetDefault("segments.model", true)
+	viperInstance.SetDefault("segments.worktree", true)
 	viperInstance.SetDefault("segments.cost", CostAuto)
 	viperInstance.SetDefault("segments.status", true)
 	viperInstance.SetDefault("segments.context", true)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -16,6 +16,10 @@ func TestDefaults(t *testing.T) {
 		t.Error("expected model segment enabled by default")
 	}
 
+	if !cfg.Segments.Worktree {
+		t.Error("expected worktree segment enabled by default")
+	}
+
 	if cfg.Segments.Cost != CostAuto {
 		t.Errorf("expected cost segment auto by default, got %q", cfg.Segments.Cost)
 	}
@@ -116,6 +120,7 @@ func TestLoadFullConfig(t *testing.T) {
 	content := `
 [segments]
 model = false
+worktree = false
 cost = false
 status = false
 context = false
@@ -136,7 +141,7 @@ status_ttl = "30s"
 
 	cfg := Load(configPath)
 
-	if cfg.Segments.Model || cfg.Segments.Cost != CostOff || cfg.Segments.Status ||
+	if cfg.Segments.Model || cfg.Segments.Worktree || cfg.Segments.Cost != CostOff || cfg.Segments.Status ||
 		cfg.Segments.Context || cfg.Segments.Compactions || cfg.Segments.Quota ||
 		cfg.Segments.Credits || cfg.Segments.OffPeak {
 		t.Error("expected all segments disabled")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -97,6 +97,10 @@ status = false
 		t.Error("expected model segment enabled (not in config)")
 	}
 
+	if !cfg.Segments.Worktree {
+		t.Error("expected worktree segment enabled (not in config)")
+	}
+
 	if cfg.Segments.Cost != CostOff {
 		t.Errorf("expected cost segment off, got %q", cfg.Segments.Cost)
 	}


### PR DESCRIPTION
## Summary

- New 🌿 worktree segment reading `workspace.git_worktree` from stdin (Claude Code v2.1.97+)
- Enabled by default, disable with `--no-worktree` or `worktree = false` in config
- Document `refreshInterval` setting so quota timers can tick during idle time
- Simplify README examples (two near-identical outputs collapsed into one rich example)
- Fix stale README after v1.0.0: correct minimum version (`v2.1.82` for `rate_limits`), replace `--no-cost` with `--cost`, complete flag list

## Why

Claude Code v2.1.97 added `workspace.git_worktree` to statusline stdin and the `refreshInterval` setting. The worktree field lets claudeline show which linked git worktree you are in — useful when juggling parallel worktrees for different tasks. `refreshInterval` makes quota reset timers keep ticking while the session is idle.

## Test plan

- [ ] CI passes (lint + test + build)
- [ ] `echo '{"workspace":{"git_worktree":"feat-api"}}' | claudeline` shows `🌿 feat-api`
- [ ] Same with `--no-worktree` omits the segment
- [ ] `claudeline validate` catches typos in the new `worktree` config key