### PR TITLE
fix: move worktree segment right, migrate to homebrew cask

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -21,17 +21,18 @@ archives:
   - formats: [tar.gz]
     name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
 
-brews:
-  - repository:
+homebrew_casks:
+  - name: claudeline
+    binaries:
+      - claudeline
+    repository:
       owner: lexfrei
       name: homebrew-tap
       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
-    directory: Formula
+    directory: Casks
     homepage: "https://github.com/lexfrei/claudeline"
-    description: "Claude Code statusline with real usage limits from Anthropic API"
-    license: "BSD-3-Clause"
-    install: |
-      bin.install "claudeline"
+    description: "Real-time statusline for Claude Code"
+    commit_msg_template: "Cask update for {{ .ProjectName }} {{ .Tag }}"
 
 checksum:
   name_template: "checksums.txt"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Real-time statusline for [Claude Code](https://docs.anthropic.com/en/docs/claude
 ## Example output
 
 ```text
-🤖 Opus 4.6 | 🌿 feat-api | 🧠 67% | 🔄 2 | 🟡 7d: 42% (4d 2h) | 🔴 5h: 91% (27m)
+🤖 Opus 4.6 | 🧠 67% | 🔄 2 | 🌿 feat-api | 🟡 7d: 42% (4d 2h) | 🔴 5h: 91% (27m)
 ```
 
 ## Segments

--- a/cmd/claudeline/main.go
+++ b/cmd/claudeline/main.go
@@ -211,6 +211,10 @@ func buildStatusline(raw []byte, cfg *config.Config) string {
 	segments = appendCostAndStatusSegments(segments, &data, cfg)
 	segments = appendContextSegments(segments, &data, cfg)
 
+	if cfg.Segments.Worktree && data.Workspace.GitWorktree != "" {
+		segments = append(segments, "🌿 "+data.Workspace.GitWorktree)
+	}
+
 	if cfg.Segments.Quota || cfg.Segments.Credits {
 		segments = appendUsageSegments(segments, &data, cfg)
 	}
@@ -218,7 +222,7 @@ func buildStatusline(raw []byte, cfg *config.Config) string {
 	return fmtutil.JoinPipe(segments)
 }
 
-// appendIdentitySegments adds model and worktree segments (who you are, where you are).
+// appendIdentitySegments adds model segment.
 func appendIdentitySegments(segments []string, data *stdinData, cfg *config.Config) []string {
 	if cfg.Segments.Model {
 		model := "Claude"
@@ -227,10 +231,6 @@ func appendIdentitySegments(segments []string, data *stdinData, cfg *config.Conf
 		}
 
 		segments = append(segments, "🤖 "+model)
-	}
-
-	if cfg.Segments.Worktree && data.Workspace.GitWorktree != "" {
-		segments = append(segments, "🌿 "+data.Workspace.GitWorktree)
 	}
 
 	return segments

--- a/cmd/claudeline/main_test.go
+++ b/cmd/claudeline/main_test.go
@@ -187,9 +187,9 @@ func TestBuildStatuslineWithWorktree(t *testing.T) {
 		t.Errorf("expected worktree segment, got %q", got)
 	}
 
-	// Worktree should appear right after model.
-	if !strings.Contains(got, "🤖 Opus 4.6 | 🌿 feat-api") {
-		t.Errorf("expected worktree right after model, got %q", got)
+	// Worktree should appear after context/compactions, before quotas.
+	if !strings.HasSuffix(got, "🌿 feat-api") {
+		t.Errorf("expected worktree as last segment (no quotas in this input), got %q", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Move worktree segment (🌿) from right-after-model to right-before-quotas: least volatile info on the left, ticking quota timers on the right
- Migrate GoReleaser from deprecated `brews` to `homebrew_casks` (deprecated since GoReleaser v2.10)

## Homebrew tap changes (already applied)

- `Formula/claudeline.rb` removed from `lexfrei/homebrew-tap`
- `tap_migrations.json` added for automatic formula-to-cask migration
- GoReleaser will now write to `Casks/claudeline.rb`