### PR TITLE
fix: revert cask migration, worktree rightmost

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -21,18 +21,17 @@ archives:
   - formats: [tar.gz]
     name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
 
-homebrew_casks:
-  - name: claudeline
-    binaries:
-      - claudeline
-    repository:
+brews:
+  - repository:
       owner: lexfrei
       name: homebrew-tap
       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
-    directory: Casks
+    directory: Formula
     homepage: "https://github.com/lexfrei/claudeline"
     description: "Real-time statusline for Claude Code"
-    commit_msg_template: "Cask update for {{ .ProjectName }} {{ .Tag }}"
+    license: "BSD-3-Clause"
+    install: |
+      bin.install "claudeline"
 
 checksum:
   name_template: "checksums.txt"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Real-time statusline for [Claude Code](https://docs.anthropic.com/en/docs/claude
 ## Example output
 
 ```text
-🤖 Opus 4.6 | 🧠 67% | 🔄 2 | 🌿 feat-api | 🟡 7d: 42% (4d 2h) | 🔴 5h: 91% (27m)
+🤖 Opus 4.6 | 🧠 67% | 🔄 2 | 🟡 7d: 42% (4d 2h) | 🔴 5h: 91% (27m) | 🌿 feat-api
 ```
 
 ## Segments

--- a/cmd/claudeline/main.go
+++ b/cmd/claudeline/main.go
@@ -211,12 +211,12 @@ func buildStatusline(raw []byte, cfg *config.Config) string {
 	segments = appendCostAndStatusSegments(segments, &data, cfg)
 	segments = appendContextSegments(segments, &data, cfg)
 
-	if cfg.Segments.Worktree && data.Workspace.GitWorktree != "" {
-		segments = append(segments, "🌿 "+data.Workspace.GitWorktree)
-	}
-
 	if cfg.Segments.Quota || cfg.Segments.Credits {
 		segments = appendUsageSegments(segments, &data, cfg)
+	}
+
+	if cfg.Segments.Worktree && data.Workspace.GitWorktree != "" {
+		segments = append(segments, "🌿 "+data.Workspace.GitWorktree)
 	}
 
 	return fmtutil.JoinPipe(segments)


### PR DESCRIPTION
## Summary

- Revert `homebrew_casks` back to `brews` — cask installs apply macOS quarantine to unsigned binaries, triggering Gatekeeper block on first run. Formulas do not have this issue
- Move worktree segment to the rightmost position (after quotas)
- Tap repo cleaned up: cask file and tap_migrations.json removed, formula will be recreated by GoReleaser on release