### PR TITLE
feat(statusline): show effort, thinking, and fast-mode indicators

### DIFF
--- a/cmd/claudeline/main.go
+++ b/cmd/claudeline/main.go
@@ -25,6 +25,13 @@ var (
 	commit  = "none"
 )
 
+const (
+	labelSevenDayOpus      = "7d-opus"
+	labelSevenDaySonnet    = "7d-sonnet"
+	labelSevenDayCowork    = "7d-cowork"
+	labelSevenDayOAuthApps = "7d-oauth"
+)
+
 type stdinRateWindow struct {
 	UsedPercentage float64 `json:"used_percentage"` //nolint:tagliatelle // External API format
 	ResetsAt       float64 `json:"resets_at"`       //nolint:tagliatelle // External API format
@@ -34,6 +41,13 @@ type stdinData struct {
 	Model struct {
 		DisplayName string `json:"display_name"` //nolint:tagliatelle // External API format
 	} `json:"model"`
+	Effort struct {
+		Level string `json:"level"`
+	} `json:"effort"`
+	Thinking struct {
+		Enabled bool `json:"enabled"`
+	} `json:"thinking"`
+	FastMode  bool `json:"fast_mode"` //nolint:tagliatelle // External API format
 	Workspace struct {
 		GitWorktree string `json:"git_worktree"` //nolint:tagliatelle // External API format
 	} `json:"workspace"`
@@ -98,6 +112,9 @@ func newRootCmd() *cobra.Command {
 	flags := rootCmd.PersistentFlags()
 	flags.StringVar(&configPath, "config", defaultConfigPath(), "config file path")
 	flags.Bool("no-model", false, "disable model segment")
+	flags.Bool("no-effort", false, "disable effort indicator on model segment")
+	flags.Bool("no-thinking", false, "disable thinking indicator on model segment")
+	flags.Bool("no-fast-mode", false, "disable fast-mode indicator on model segment")
 	flags.Bool("no-worktree", false, "disable worktree segment")
 	flags.String("cost", "", "cost segment mode: auto (default), true, false")
 	flags.Bool("no-status", false, "disable status segment")
@@ -137,14 +154,34 @@ func newValidateCmd(configPath *string) *cobra.Command {
 }
 
 func applyFlagOverrides(cmd *cobra.Command, cfg *config.Config) {
+	applyIdentityFlags(cmd, cfg)
+	applyDisplayFlags(cmd, cfg)
+	applyUsageFlags(cmd, cfg)
+}
+
+func applyIdentityFlags(cmd *cobra.Command, cfg *config.Config) {
 	if flagSet(cmd, "no-model") {
 		cfg.Segments.Model = false
+	}
+
+	if flagSet(cmd, "no-effort") {
+		cfg.Segments.Effort = false
+	}
+
+	if flagSet(cmd, "no-thinking") {
+		cfg.Segments.Thinking = false
+	}
+
+	if flagSet(cmd, "no-fast-mode") {
+		cfg.Segments.FastMode = false
 	}
 
 	if flagSet(cmd, "no-worktree") {
 		cfg.Segments.Worktree = false
 	}
+}
 
+func applyDisplayFlags(cmd *cobra.Command, cfg *config.Config) {
 	if flagSet(cmd, "cost") {
 		if val, _ := cmd.PersistentFlags().GetString("cost"); val != "" {
 			cfg.Segments.Cost = val
@@ -162,7 +199,9 @@ func applyFlagOverrides(cmd *cobra.Command, cfg *config.Config) {
 	if flagSet(cmd, "no-compactions") {
 		cfg.Segments.Compactions = false
 	}
+}
 
+func applyUsageFlags(cmd *cobra.Command, cfg *config.Config) {
 	if flagSet(cmd, "no-quota") {
 		cfg.Segments.Quota = false
 	}
@@ -230,10 +269,51 @@ func appendIdentitySegments(segments []string, data *stdinData, cfg *config.Conf
 			model = data.Model.DisplayName
 		}
 
+		if suffix := formatModelSuffix(data, cfg); suffix != "" {
+			model += " " + suffix
+		}
+
 		segments = append(segments, "🤖 "+model)
 	}
 
 	return segments
+}
+
+// formatModelSuffix builds the indicator suffix appended to the model name.
+// Combines effort level, thinking, and fast-mode flags into a single string.
+func formatModelSuffix(data *stdinData, cfg *config.Config) string {
+	var parts []string
+
+	if cfg.Segments.Effort {
+		if e := effortIndicator(data.Effort.Level); e != "" {
+			parts = append(parts, e)
+		}
+	}
+
+	if cfg.Segments.Thinking && data.Thinking.Enabled {
+		parts = append(parts, "💭")
+	}
+
+	if cfg.Segments.FastMode && data.FastMode {
+		parts = append(parts, "⚡")
+	}
+
+	return strings.Join(parts, "")
+}
+
+func effortIndicator(level string) string {
+	switch level {
+	case "low":
+		return "⬇️"
+	case "high":
+		return "⬆️"
+	case "xhigh":
+		return "⏫"
+	case "max":
+		return "🚀"
+	default:
+		return ""
+	}
 }
 
 // appendCostAndStatusSegments adds cost and platform status segments.
@@ -317,10 +397,10 @@ func appendQuotaWindows(segments []string, data *fmtutil.Data, perModel bool, pr
 
 	if perModel {
 		windows = append(windows,
-			labeledWindow{data.SevenDayOpus, "7d-opus"},
-			labeledWindow{data.SevenDaySonnet, "7d-sonnet"},
-			labeledWindow{data.SevenDayCowork, "7d-cowork"},
-			labeledWindow{data.SevenDayOAuthApps, "7d-oauth"},
+			labeledWindow{data.SevenDayOpus, labelSevenDayOpus},
+			labeledWindow{data.SevenDaySonnet, labelSevenDaySonnet},
+			labeledWindow{data.SevenDayCowork, labelSevenDayCowork},
+			labeledWindow{data.SevenDayOAuthApps, labelSevenDayOAuthApps},
 		)
 	}
 
@@ -407,10 +487,10 @@ func appendStaleQuotaSegments(segments []string, perModel bool, promo promotion.
 
 	if perModel {
 		windows = append(windows,
-			labeledWindow{lastGood.SevenDayOpus, "7d-opus"},
-			labeledWindow{lastGood.SevenDaySonnet, "7d-sonnet"},
-			labeledWindow{lastGood.SevenDayCowork, "7d-cowork"},
-			labeledWindow{lastGood.SevenDayOAuthApps, "7d-oauth"},
+			labeledWindow{lastGood.SevenDayOpus, labelSevenDayOpus},
+			labeledWindow{lastGood.SevenDaySonnet, labelSevenDaySonnet},
+			labeledWindow{lastGood.SevenDayCowork, labelSevenDayCowork},
+			labeledWindow{lastGood.SevenDayOAuthApps, labelSevenDayOAuthApps},
 		)
 	}
 

--- a/cmd/claudeline/main_test.go
+++ b/cmd/claudeline/main_test.go
@@ -18,7 +18,12 @@ import (
 	"github.com/lexfrei/claudeline/internal/usage"
 )
 
-const testToken = "test-token"
+const (
+	testToken       = "test-token"
+	testModelOpus47 = "🤖 Opus 4.7"
+	flagNoModel     = "--no-model"
+	flagNoWorktree  = "--no-worktree"
+)
 
 func defaultCfg() *config.Config {
 	cfg := config.Defaults()
@@ -262,6 +267,121 @@ func TestBuildStatuslineWithModel(t *testing.T) {
 
 	if !strings.Contains(got, "💰 $42.50") {
 		t.Errorf("expected $42.50, got %q", got)
+	}
+}
+
+func TestBuildStatuslineEffortLevels(t *testing.T) {
+	cleanup := setupTestEnv(t)
+	defer cleanup()
+
+	keychain.GetFn = func() (string, error) { return "", keychain.ErrNoToken }
+	status.HTTPGetFn = failHTTP
+	usage.HTTPGetFn = failHTTP
+
+	cases := []struct {
+		level    string
+		expected string
+	}{
+		{"low", "🤖 Opus 4.7 ⬇️"},
+		{"medium", testModelOpus47},
+		{"high", "🤖 Opus 4.7 ⬆️"},
+		{"xhigh", "🤖 Opus 4.7 ⏫"},
+		{"max", "🤖 Opus 4.7 🚀"},
+		{"", testModelOpus47},
+		{"unknown", testModelOpus47},
+	}
+
+	for _, tcase := range cases {
+		t.Run(tcase.level, func(t *testing.T) {
+			input := fmt.Sprintf(`{"model":{"display_name":"Opus 4.7"},"effort":{"level":%q}}`, tcase.level)
+
+			got := buildStatusline([]byte(input), defaultCfg())
+			if !strings.Contains(got, tcase.expected) {
+				t.Errorf("level=%q: expected %q, got %q", tcase.level, tcase.expected, got)
+			}
+
+			// Medium and unknown levels must not emit any effort indicator.
+			if tcase.level == "medium" || tcase.level == "" || tcase.level == "unknown" {
+				for _, ind := range []string{"⬇️", "⬆️", "⏫", "🚀"} {
+					if strings.Contains(got, ind) {
+						t.Errorf("level=%q: unexpected indicator %q, got %q", tcase.level, ind, got)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestBuildStatuslineThinkingIndicator(t *testing.T) {
+	cleanup := setupTestEnv(t)
+	defer cleanup()
+
+	keychain.GetFn = func() (string, error) { return "", keychain.ErrNoToken }
+	status.HTTPGetFn = failHTTP
+	usage.HTTPGetFn = failHTTP
+
+	input := `{"model":{"display_name":"Opus 4.7"},"thinking":{"enabled":true}}`
+	got := buildStatusline([]byte(input), defaultCfg())
+
+	if !strings.Contains(got, "🤖 Opus 4.7 💭") {
+		t.Errorf("expected thinking indicator, got %q", got)
+	}
+}
+
+func TestBuildStatuslineFastModeIndicator(t *testing.T) {
+	cleanup := setupTestEnv(t)
+	defer cleanup()
+
+	keychain.GetFn = func() (string, error) { return "", keychain.ErrNoToken }
+	status.HTTPGetFn = failHTTP
+	usage.HTTPGetFn = failHTTP
+
+	input := `{"model":{"display_name":"Opus 4.6"},"fast_mode":true}`
+	got := buildStatusline([]byte(input), defaultCfg())
+
+	if !strings.Contains(got, "🤖 Opus 4.6 ⚡") {
+		t.Errorf("expected fast-mode indicator, got %q", got)
+	}
+}
+
+func TestBuildStatuslineCombinedIndicators(t *testing.T) {
+	cleanup := setupTestEnv(t)
+	defer cleanup()
+
+	keychain.GetFn = func() (string, error) { return "", keychain.ErrNoToken }
+	status.HTTPGetFn = failHTTP
+	usage.HTTPGetFn = failHTTP
+
+	input := `{"model":{"display_name":"Opus 4.7"},"effort":{"level":"high"},"thinking":{"enabled":true},"fast_mode":true}`
+	got := buildStatusline([]byte(input), defaultCfg())
+
+	if !strings.Contains(got, "🤖 Opus 4.7 ⬆️💭⚡") {
+		t.Errorf("expected combined indicators, got %q", got)
+	}
+}
+
+func TestBuildStatuslineIndicatorsDisabled(t *testing.T) {
+	cleanup := setupTestEnv(t)
+	defer cleanup()
+
+	keychain.GetFn = func() (string, error) { return "", keychain.ErrNoToken }
+	status.HTTPGetFn = failHTTP
+	usage.HTTPGetFn = failHTTP
+
+	cfg := defaultCfg()
+	cfg.Segments.Effort = false
+	cfg.Segments.Thinking = false
+	cfg.Segments.FastMode = false
+
+	input := `{"model":{"display_name":"Opus 4.7"},"effort":{"level":"max"},"thinking":{"enabled":true},"fast_mode":true}`
+
+	got := buildStatusline([]byte(input), cfg)
+	if strings.Contains(got, "🚀") || strings.Contains(got, "💭") || strings.Contains(got, "⚡") {
+		t.Errorf("expected no indicators when disabled, got %q", got)
+	}
+
+	if !strings.Contains(got, testModelOpus47) {
+		t.Errorf("expected bare model name, got %q", got)
 	}
 }
 
@@ -650,7 +770,7 @@ func TestNewRootCmdWithFlags(t *testing.T) {
 	usage.HTTPGetFn = failHTTP
 
 	cmd := newRootCmd()
-	cmd.SetArgs([]string{"--no-model", "--no-worktree", "--cost", "false", "--config", "/nonexistent/config.toml"})
+	cmd.SetArgs([]string{flagNoModel, flagNoWorktree, "--cost", "false", "--config", "/nonexistent/config.toml"})
 	cmd.SetIn(strings.NewReader(`{"workspace":{"git_worktree":"feat-api"}}`))
 
 	captured := captureStdout(t, func() {
@@ -743,9 +863,9 @@ usage_ttl = "30s"
 
 func TestApplyFlagOverrides(t *testing.T) {
 	cmd := newRootCmd()
-	cmd.SetArgs([]string{"--no-model", "--no-worktree", "--no-quota", "--no-credits", "--per-model-quota", "--no-offpeak", "--mac-insecure"})
+	cmd.SetArgs([]string{flagNoModel, flagNoWorktree, "--no-quota", "--no-credits", "--per-model-quota", "--no-offpeak", "--mac-insecure"})
 
-	parseErr := cmd.ParseFlags([]string{"--no-model", "--no-worktree", "--no-quota", "--no-credits", "--per-model-quota", "--no-offpeak", "--mac-insecure"})
+	parseErr := cmd.ParseFlags([]string{flagNoModel, flagNoWorktree, "--no-quota", "--no-credits", "--per-model-quota", "--no-offpeak", "--mac-insecure"})
 	if parseErr != nil {
 		t.Fatal(parseErr)
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -39,6 +39,9 @@ func NormalizeCostMode(raw string) string {
 // Segments controls which statusline segments are displayed.
 type Segments struct {
 	Model         bool   `mapstructure:"model"`
+	Effort        bool   `mapstructure:"effort"`
+	Thinking      bool   `mapstructure:"thinking"`
+	FastMode      bool   `mapstructure:"fast_mode"`
 	Worktree      bool   `mapstructure:"worktree"`
 	Cost          string `mapstructure:"cost"`
 	Status        bool   `mapstructure:"status"`
@@ -68,6 +71,9 @@ func Defaults() Config {
 	return Config{
 		Segments: Segments{
 			Model:       true,
+			Effort:      true,
+			Thinking:    true,
+			FastMode:    true,
 			Worktree:    true,
 			Cost:        CostAuto,
 			Status:      true,
@@ -124,6 +130,9 @@ func Load(configPath string) Config {
 // knownKeys is the set of all valid configuration keys.
 var knownKeys = map[string]bool{
 	"segments.model":           true,
+	"segments.effort":          true,
+	"segments.thinking":        true,
+	"segments.fast_mode":       true,
 	"segments.worktree":        true,
 	"segments.cost":            true,
 	"segments.status":          true,
@@ -190,6 +199,9 @@ func validateSegments(seg *Segments, v *viper.Viper) []string {
 		raw any
 	}{
 		{"segments.model", v.Get("segments.model")},
+		{"segments.effort", v.Get("segments.effort")},
+		{"segments.thinking", v.Get("segments.thinking")},
+		{"segments.fast_mode", v.Get("segments.fast_mode")},
 		{"segments.worktree", v.Get("segments.worktree")},
 		{"segments.status", v.Get("segments.status")},
 		{"segments.context", v.Get("segments.context")},
@@ -235,6 +247,9 @@ func validateCache(cache *Cache) []string {
 
 func setViperDefaults(viperInstance *viper.Viper) {
 	viperInstance.SetDefault("segments.model", true)
+	viperInstance.SetDefault("segments.effort", true)
+	viperInstance.SetDefault("segments.thinking", true)
+	viperInstance.SetDefault("segments.fast_mode", true)
 	viperInstance.SetDefault("segments.worktree", true)
 	viperInstance.SetDefault("segments.cost", CostAuto)
 	viperInstance.SetDefault("segments.status", true)

--- a/internal/fmtutil/format.go
+++ b/internal/fmtutil/format.go
@@ -29,10 +29,13 @@ const (
 // ErrCannotParseTimestamp is returned when a timestamp string cannot be parsed.
 var ErrCannotParseTimestamp = errors.New("cannot parse timestamp")
 
+// DurationNow is the rendering used for non-positive durations.
+const DurationNow = "now"
+
 // Duration returns a human-readable duration from minutes.
 func Duration(minutes int) string {
 	if minutes <= 0 {
-		return "now"
+		return DurationNow
 	}
 
 	days := minutes / minutesPerDay

--- a/internal/fmtutil/format_test.go
+++ b/internal/fmtutil/format_test.go
@@ -13,8 +13,8 @@ func TestDuration(t *testing.T) {
 		minutes int
 		want    string
 	}{
-		{0, "now"},
-		{-5, "now"},
+		{0, DurationNow},
+		{-5, DurationNow},
 		{7, "7m"},
 		{60, "1h 0m"},
 		{125, "2h 5m"},

--- a/internal/usage/usage_test.go
+++ b/internal/usage/usage_test.go
@@ -16,6 +16,15 @@ const (
 	testToken     = "test-token"
 	authErrorType = "authentication_error"
 	rateLimitType = "rate_limit_error"
+
+	headerRetryAfter            = "Retry-After"
+	headerContentType           = "Content-Type"
+	headerContentSecurityPolicy = "Content-Security-Policy"
+	headerXRobotsTag            = "X-Robots-Tag"
+
+	mimeJSON   = "application/json"
+	cspNone    = "default-src 'none'; frame-ancestors 'none'"
+	robotsNone = "none"
 )
 
 var errTest = errors.New("test error")
@@ -213,12 +222,12 @@ func TestParseRetryAfterSeconds(t *testing.T) {
 	}{
 		{
 			name:     "valid seconds",
-			header:   http.Header{"Retry-After": []string{"6"}},
+			header:   http.Header{headerRetryAfter: []string{"6"}},
 			expected: 6,
 		},
 		{
 			name:     "zero seconds",
-			header:   http.Header{"Retry-After": []string{"0"}},
+			header:   http.Header{headerRetryAfter: []string{"0"}},
 			expected: 0,
 		},
 		{
@@ -228,12 +237,12 @@ func TestParseRetryAfterSeconds(t *testing.T) {
 		},
 		{
 			name:     "negative value clamped to zero",
-			header:   http.Header{"Retry-After": []string{"-5"}},
+			header:   http.Header{headerRetryAfter: []string{"-5"}},
 			expected: 0,
 		},
 		{
 			name:     "non-numeric value uses default",
-			header:   http.Header{"Retry-After": []string{"Wed, 11 Mar 2026 18:44:10 GMT"}},
+			header:   http.Header{headerRetryAfter: []string{"Wed, 11 Mar 2026 18:44:10 GMT"}},
 			expected: defaultRetryAfterSeconds,
 		},
 	}
@@ -364,7 +373,7 @@ func TestFetchRateLimitedRespectsRetryAfter(t *testing.T) {
 		return &httpclient.Response{
 			StatusCode: http.StatusTooManyRequests,
 			Body:       []byte(`{"error":{"type":"rate_limit_error"}}`),
-			Header:     http.Header{"Retry-After": []string{"6"}},
+			Header:     http.Header{headerRetryAfter: []string{"6"}},
 		}, nil
 	}
 
@@ -427,7 +436,7 @@ func TestFetchRateLimitedNotCachedInMainCache(t *testing.T) {
 		return &httpclient.Response{
 			StatusCode: http.StatusTooManyRequests,
 			Body:       []byte(`{"error":{"type":"rate_limit_error"}}`),
-			Header:     http.Header{"Retry-After": []string{"6"}},
+			Header:     http.Header{headerRetryAfter: []string{"6"}},
 		}, nil
 	}
 
@@ -626,7 +635,7 @@ func TestFetchRateLimitedWithNonJSONBody(t *testing.T) {
 		return &httpclient.Response{
 			StatusCode: http.StatusTooManyRequests,
 			Body:       []byte(`Rate limited. Please try again later.`),
-			Header:     http.Header{"Retry-After": []string{"10"}},
+			Header:     http.Header{headerRetryAfter: []string{"10"}},
 		}, nil
 	}
 
@@ -704,13 +713,13 @@ func TestFetchWithReal429Response(t *testing.T) {
 			StatusCode: http.StatusTooManyRequests,
 			Body:       []byte(real429Body),
 			Header: http.Header{
-				"Content-Type":            []string{"application/json"},
-				"Retry-After":             []string{"6"},
-				"Cache-Control":           []string{"private, max-age=0, no-store, no-cache, must-revalidate, post-check=0, pre-check=0"},
-				"Referrer-Policy":         []string{"same-origin"},
-				"X-Frame-Options":         []string{"SAMEORIGIN"},
-				"Content-Security-Policy": []string{"default-src 'none'; frame-ancestors 'none'"},
-				"X-Robots-Tag":            []string{"none"},
+				headerContentType:           []string{mimeJSON},
+				headerRetryAfter:            []string{"6"},
+				"Cache-Control":             []string{"private, max-age=0, no-store, no-cache, must-revalidate, post-check=0, pre-check=0"},
+				"Referrer-Policy":           []string{"same-origin"},
+				"X-Frame-Options":           []string{"SAMEORIGIN"},
+				headerContentSecurityPolicy: []string{cspNone},
+				headerXRobotsTag:            []string{robotsNone},
 			},
 		}, nil
 	}
@@ -751,11 +760,11 @@ func TestFetchWithReal401Response(t *testing.T) {
 			StatusCode: http.StatusUnauthorized,
 			Body:       []byte(real401Body),
 			Header: http.Header{
-				"Content-Type":            []string{"application/json"},
-				"X-Should-Retry":          []string{"false"},
-				"Request-Id":              []string{"req_011CYwnYqWfPFkeKDkDmyKqs"},
-				"Content-Security-Policy": []string{"default-src 'none'; frame-ancestors 'none'"},
-				"X-Robots-Tag":            []string{"none"},
+				headerContentType:           []string{mimeJSON},
+				"X-Should-Retry":            []string{"false"},
+				"Request-Id":                []string{"req_011CYwnYqWfPFkeKDkDmyKqs"},
+				headerContentSecurityPolicy: []string{cspNone},
+				headerXRobotsTag:            []string{robotsNone},
 			},
 		}, nil
 	}
@@ -799,11 +808,11 @@ func TestFetchWithReal200Response(t *testing.T) {
 			StatusCode: http.StatusOK,
 			Body:       []byte(real200Body),
 			Header: http.Header{
-				"Content-Type":              []string{"application/json"},
+				headerContentType:           []string{mimeJSON},
 				"Request-Id":                []string{"req_011CYwnbPgEDyqe7p3VQohKX"},
 				"Anthropic-Organization-Id": []string{"71f33990-619b-49dd-9175-8df9803e8b59"},
-				"Content-Security-Policy":   []string{"default-src 'none'; frame-ancestors 'none'"},
-				"X-Robots-Tag":              []string{"none"},
+				headerContentSecurityPolicy: []string{cspNone},
+				headerXRobotsTag:            []string{robotsNone},
 			},
 		}, nil
 	}


### PR DESCRIPTION
## What's New

Display reasoning effort, thinking mode, and Opus 4.6 fast mode as compact indicators next to the model name. Closes #3.

Claude Code 2.1.119 added `effort.level`, `thinking.enabled`, and `fast_mode` to the statusline stdin payload — claudeline now consumes them.

### Indicators

  - effort `low` → `⬇️`
  - effort `medium` → no indicator (default)
  - effort `high` → `⬆️`
  - effort `xhigh` → `⏫`
  - effort `max` → `🚀`
  - `thinking.enabled: true` → `💭`
  - `fast_mode: true` → `⚡`

Indicators concatenate without separator when multiple apply, e.g. `🤖 Opus 4.7 ⬆️💭`.

### Config

```toml
[segments]
effort = true     # default
thinking = true   # default
fast_mode = true  # default
```

CLI flags: `--no-effort`, `--no-thinking`, `--no-fast-mode`.

## Why

The new stdin fields land in claudeline's secure (default) path, so users can see at a glance whether the running session is on `xhigh` effort with thinking enabled, or in fast mode — without opening `/effort` or `/model`.

## Notes

  - Defaults preserve current behavior on stale Claude Code versions: when fields are absent, no indicators render.
  - The chosen symbols are debatable — see #15 for tracking config-driven symbol overrides.
  - Refactored `applyFlagOverrides` into identity/display/usage helpers to keep cyclomatic complexity within limits after adding three flags.
  - Hoisted a few repeated string literals (`7d-opus`, `7d-sonnet`, `7d-cowork`, `7d-oauth`, `--no-model`, `--no-worktree`) to package constants to satisfy `goconst`.
