### PR TITLE
feat(statusline): combined repo, PR, and worktree segment

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,21 +9,38 @@ Real-time statusline for [Claude Code](https://docs.anthropic.com/en/docs/claude
 ## Example output
 
 ```text
-🤖 Opus 4.6 | 🧠 67% | 🔄 2 | 🟡 7d: 42% (4d 2h) | 🔴 5h: 91% (27m) | 🌿 feat-api
+🤖 Opus 4.7 ⏫💭 | 🧠 67% | 🔄 2 | 🟡 7d: 42% (4d 2h) | 🔴 5h: 91% (27m) | 🐙 lexfrei/claudeline #19 📝 @ feat-api
 ```
 
 ## Segments
 
 | Segment | Description |
 | --- | --- |
-| 🤖 Model | Active model name |
-| 🌿 Worktree | Git worktree name when cwd is inside a linked worktree (Claude Code v2.1.97+) |
+| 🤖 Model | Active model name, with effort / thinking / fast-mode indicators (Claude Code v2.1.119+) |
+| 🐙 Repo | Repository host icon, `owner/name`, optional `#PR <state>`, optional `@ worktree` (Claude Code v2.1.145+) |
+| 🌿 Worktree | Bare worktree fallback when no repository info is available |
 | 💰 Cost | Cumulative session cost in USD (hidden by default for subscribers, see [Cost mode](#cost-mode)) |
 | ⚠️/🔶/🔴 Status | Anthropic platform status: ⚠️ degraded, 🔶 major outage, 🔴 critical (hidden when all clear) |
 | 🧠 Context | Context window usage percentage (color-coded) |
 | 🔄 Compactions | Number of context compactions in current session |
 | 🟢/🟡/🟠/🔴 7d | 7-day rolling quota utilization with time until reset |
 | 🟢/🟡/🟠/🔴 5h | 5-hour rolling quota utilization with time until reset (⬆ during off-peak promotions) |
+
+### Model indicators
+
+  - effort `low` → `⬇️`, `medium` → no indicator, `high` → `⬆️`, `xhigh` → `⏫`, `max` → `🚀`
+  - thinking enabled → `💭`
+  - fast mode → `⚡`
+
+### Repo segment
+
+Renders when Claude Code reports `workspace.repo` (a git remote pointing at a known host):
+
+  - `🐙` github.com, `🦊` gitlab.com, `🪣` bitbucket.org, `📦` other hosts (with `host/` prefix)
+  - `#N` followed by review state: `📝` draft, `👀` pending, `💬` commented, `🔴` changes requested, `✅` approved
+  - `@ branch` when inside a linked worktree
+
+When no `workspace.repo` is present (non-git or detached state), the segment falls back to the bare worktree form (`🌿 branch`).
 
 Quota indicators compare your usage rate against elapsed time to warn about hitting limits:
 
@@ -52,6 +69,8 @@ Disable with `--no-offpeak` or `offpeak = false` in config.
 
 - Claude Code v2.1.82+ (provides `rate_limits` in statusline stdin)
 - Claude Code v2.1.97+ recommended (adds `workspace.git_worktree` and `refreshInterval`)
+- Claude Code v2.1.119+ enables effort, thinking, and fast-mode indicators
+- Claude Code v2.1.145+ enables the combined repo / PR segment
 
 ## Installation
 
@@ -109,6 +128,10 @@ Optional config file at `~/.claudelinerc.toml`:
 ```toml
 [segments]
 model = true
+effort = true
+thinking = true
+fast_mode = true
+repo = true
 worktree = true
 cost = "auto"
 status = true
@@ -134,7 +157,7 @@ claudeline --cost false --no-status
 claudeline --config /path/to/config.toml
 ```
 
-Available flags: `--no-model`, `--no-worktree`, `--cost`, `--no-status`, `--no-context`, `--no-compactions`, `--no-quota`, `--no-offpeak`, `--mac-insecure`, `--per-model-quota`, `--no-credits`. The last two only take effect with `--mac-insecure`.
+Available flags: `--no-model`, `--no-effort`, `--no-thinking`, `--no-fast-mode`, `--no-repo`, `--no-worktree`, `--cost`, `--no-status`, `--no-context`, `--no-compactions`, `--no-quota`, `--no-offpeak`, `--mac-insecure`, `--per-model-quota`, `--no-credits`. The last two only take effect with `--mac-insecure`.
 
 ## Advanced: `--mac-insecure` mode
 

--- a/cmd/claudeline/main.go
+++ b/cmd/claudeline/main.go
@@ -37,6 +37,18 @@ type stdinRateWindow struct {
 	ResetsAt       float64 `json:"resets_at"`       //nolint:tagliatelle // External API format
 }
 
+type stdinRepoInfo struct {
+	Host  string `json:"host"`
+	Owner string `json:"owner"`
+	Name  string `json:"name"`
+}
+
+type stdinPRInfo struct {
+	Number      int    `json:"number"`
+	URL         string `json:"url"`
+	ReviewState string `json:"review_state"` //nolint:tagliatelle // External API format
+}
+
 type stdinData struct {
 	Model struct {
 		DisplayName string `json:"display_name"` //nolint:tagliatelle // External API format
@@ -49,8 +61,10 @@ type stdinData struct {
 	} `json:"thinking"`
 	FastMode  bool `json:"fast_mode"` //nolint:tagliatelle // External API format
 	Workspace struct {
-		GitWorktree string `json:"git_worktree"` //nolint:tagliatelle // External API format
+		GitWorktree string         `json:"git_worktree"` //nolint:tagliatelle // External API format
+		Repo        *stdinRepoInfo `json:"repo"`
 	} `json:"workspace"`
+	PR   *stdinPRInfo `json:"pr"`
 	Cost struct {
 		TotalCostUSD float64 `json:"total_cost_usd"` //nolint:tagliatelle // External API format
 	} `json:"cost"`
@@ -115,6 +129,7 @@ func newRootCmd() *cobra.Command {
 	flags.Bool("no-effort", false, "disable effort indicator on model segment")
 	flags.Bool("no-thinking", false, "disable thinking indicator on model segment")
 	flags.Bool("no-fast-mode", false, "disable fast-mode indicator on model segment")
+	flags.Bool("no-repo", false, "disable combined repo/PR segment (falls back to bare worktree)")
 	flags.Bool("no-worktree", false, "disable worktree segment")
 	flags.String("cost", "", "cost segment mode: auto (default), true, false")
 	flags.Bool("no-status", false, "disable status segment")
@@ -174,6 +189,10 @@ func applyIdentityFlags(cmd *cobra.Command, cfg *config.Config) {
 
 	if flagSet(cmd, "no-fast-mode") {
 		cfg.Segments.FastMode = false
+	}
+
+	if flagSet(cmd, "no-repo") {
+		cfg.Segments.Repo = false
 	}
 
 	if flagSet(cmd, "no-worktree") {
@@ -254,11 +273,86 @@ func buildStatusline(raw []byte, cfg *config.Config) string {
 		segments = appendUsageSegments(segments, &data, cfg)
 	}
 
-	if cfg.Segments.Worktree && data.Workspace.GitWorktree != "" {
-		segments = append(segments, "🌿 "+data.Workspace.GitWorktree)
-	}
+	segments = appendRepoSegment(segments, &data, cfg)
 
 	return fmtutil.JoinPipe(segments)
+}
+
+// appendRepoSegment renders the combined repo/PR/worktree segment, or falls
+// back to the bare worktree segment when no repo info is available.
+func appendRepoSegment(segments []string, data *stdinData, cfg *config.Config) []string {
+	if cfg.Segments.Repo && data.Workspace.Repo != nil {
+		return append(segments, formatRepoSegment(data))
+	}
+
+	if cfg.Segments.Worktree && data.Workspace.GitWorktree != "" {
+		return append(segments, "🌿 "+data.Workspace.GitWorktree)
+	}
+
+	return segments
+}
+
+// formatRepoSegment builds the combined repo segment:
+//
+//	🐙 owner/repo [#N <state>] [@ worktree]
+//
+// Host icon varies by `workspace.repo.host`; unknown hosts surface as
+// "📦 host/owner/repo" so the source is still legible.
+func formatRepoSegment(data *stdinData) string {
+	repo := data.Workspace.Repo
+	icon, prefix := repoHostIcon(repo.Host)
+
+	parts := []string{icon + " " + prefix + repo.Owner + "/" + repo.Name}
+
+	if data.PR != nil && data.PR.Number > 0 {
+		prPart := fmt.Sprintf("#%d", data.PR.Number)
+		if state := prReviewIcon(data.PR.ReviewState); state != "" {
+			prPart += " " + state
+		}
+
+		parts = append(parts, prPart)
+	}
+
+	if data.Workspace.GitWorktree != "" {
+		parts = append(parts, "@ "+data.Workspace.GitWorktree)
+	}
+
+	return strings.Join(parts, " ")
+}
+
+// repoHostIcon returns the leading emoji and an optional host prefix.
+// Known hosts get a dedicated icon and no prefix; unknown hosts get a
+// generic icon and "<host>/" prefix so the origin stays visible.
+func repoHostIcon(host string) (icon, prefix string) {
+	switch host {
+	case "github.com":
+		return "🐙", ""
+	case "gitlab.com":
+		return "🦊", ""
+	case "bitbucket.org":
+		return "🪣", ""
+	case "":
+		return "📦", ""
+	default:
+		return "📦", host + "/"
+	}
+}
+
+func prReviewIcon(state string) string {
+	switch state {
+	case "draft":
+		return "📝"
+	case "approved":
+		return "✅"
+	case "changes_requested":
+		return "🔴"
+	case "commented":
+		return "💬"
+	case "pending":
+		return "👀"
+	default:
+		return ""
+	}
 }
 
 // appendIdentitySegments adds model segment.

--- a/cmd/claudeline/main_test.go
+++ b/cmd/claudeline/main_test.go
@@ -250,6 +250,142 @@ func TestBuildStatuslineWorktreeDisabled(t *testing.T) {
 	}
 }
 
+func TestBuildStatuslineRepoSegment(t *testing.T) {
+	cleanup := setupTestEnv(t)
+	defer cleanup()
+
+	status.HTTPGetFn = failHTTP
+
+	cases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "github repo only",
+			input:    `{"workspace":{"repo":{"host":"github.com","owner":"lexfrei","name":"claudeline"}}}`,
+			expected: "🐙 lexfrei/claudeline",
+		},
+		{
+			name:     "github repo with worktree",
+			input:    `{"workspace":{"repo":{"host":"github.com","owner":"lexfrei","name":"claudeline"},"git_worktree":"feat-api"}}`,
+			expected: "🐙 lexfrei/claudeline @ feat-api",
+		},
+		{
+			name:     "github repo with draft PR",
+			input:    `{"workspace":{"repo":{"host":"github.com","owner":"lexfrei","name":"claudeline"}},"pr":{"number":19,"review_state":"draft"}}`,
+			expected: "🐙 lexfrei/claudeline #19 📝",
+		},
+		{
+			name:     "github repo with approved PR and worktree",
+			input:    `{"workspace":{"repo":{"host":"github.com","owner":"lexfrei","name":"claudeline"},"git_worktree":"feat-api"},"pr":{"number":42,"review_state":"approved"}}`,
+			expected: "🐙 lexfrei/claudeline #42 ✅ @ feat-api",
+		},
+		{
+			name:     "changes_requested",
+			input:    `{"workspace":{"repo":{"host":"github.com","owner":"a","name":"b"}},"pr":{"number":1,"review_state":"changes_requested"}}`,
+			expected: "🐙 a/b #1 🔴",
+		},
+		{
+			name:     "commented",
+			input:    `{"workspace":{"repo":{"host":"github.com","owner":"a","name":"b"}},"pr":{"number":1,"review_state":"commented"}}`,
+			expected: "🐙 a/b #1 💬",
+		},
+		{
+			name:     "pending review",
+			input:    `{"workspace":{"repo":{"host":"github.com","owner":"a","name":"b"}},"pr":{"number":1,"review_state":"pending"}}`,
+			expected: "🐙 a/b #1 👀",
+		},
+		{
+			name:     "PR without known review_state hides state icon",
+			input:    `{"workspace":{"repo":{"host":"github.com","owner":"a","name":"b"}},"pr":{"number":1,"review_state":"unknown"}}`,
+			expected: "🐙 a/b #1",
+		},
+		{
+			name:     "gitlab host",
+			input:    `{"workspace":{"repo":{"host":"gitlab.com","owner":"group","name":"proj"}}}`,
+			expected: "🦊 group/proj",
+		},
+		{
+			name:     "bitbucket host",
+			input:    `{"workspace":{"repo":{"host":"bitbucket.org","owner":"team","name":"app"}}}`,
+			expected: "🪣 team/app",
+		},
+		{
+			name:     "unknown host surfaces host prefix",
+			input:    `{"workspace":{"repo":{"host":"git.example.com","owner":"o","name":"r"}}}`,
+			expected: "📦 git.example.com/o/r",
+		},
+	}
+
+	for _, tcase := range cases {
+		t.Run(tcase.name, func(t *testing.T) {
+			got := buildStatusline([]byte(tcase.input), defaultCfg())
+			if !strings.Contains(got, tcase.expected) {
+				t.Errorf("expected %q in %q", tcase.expected, got)
+			}
+		})
+	}
+}
+
+func TestBuildStatuslineRepoFallbackToWorktree(t *testing.T) {
+	cleanup := setupTestEnv(t)
+	defer cleanup()
+
+	status.HTTPGetFn = failHTTP
+
+	// No repo info — should render bare worktree segment.
+	input := `{"workspace":{"git_worktree":"feat-api"}}`
+	got := buildStatusline([]byte(input), defaultCfg())
+
+	if !strings.Contains(got, "🌿 feat-api") {
+		t.Errorf("expected bare worktree fallback, got %q", got)
+	}
+
+	if strings.Contains(got, "🐙") {
+		t.Errorf("expected no repo icon when repo absent, got %q", got)
+	}
+}
+
+func TestBuildStatuslineRepoDisabledFallsBackToWorktree(t *testing.T) {
+	cleanup := setupTestEnv(t)
+	defer cleanup()
+
+	status.HTTPGetFn = failHTTP
+
+	cfg := defaultCfg()
+	cfg.Segments.Repo = false
+
+	input := `{"workspace":{"repo":{"host":"github.com","owner":"o","name":"r"},"git_worktree":"feat-api"}}`
+
+	got := buildStatusline([]byte(input), cfg)
+	if !strings.Contains(got, "🌿 feat-api") {
+		t.Errorf("expected bare worktree fallback when repo disabled, got %q", got)
+	}
+
+	if strings.Contains(got, "🐙") {
+		t.Errorf("expected no repo segment when disabled, got %q", got)
+	}
+}
+
+func TestBuildStatuslineBothRepoAndWorktreeDisabled(t *testing.T) {
+	cleanup := setupTestEnv(t)
+	defer cleanup()
+
+	status.HTTPGetFn = failHTTP
+
+	cfg := defaultCfg()
+	cfg.Segments.Repo = false
+	cfg.Segments.Worktree = false
+
+	input := `{"workspace":{"repo":{"host":"github.com","owner":"o","name":"r"},"git_worktree":"feat-api"}}`
+
+	got := buildStatusline([]byte(input), cfg)
+	if strings.Contains(got, "🐙") || strings.Contains(got, "🌿") {
+		t.Errorf("expected no repo or worktree segment, got %q", got)
+	}
+}
+
 func TestBuildStatuslineWithModel(t *testing.T) {
 	cleanup := setupTestEnv(t)
 	defer cleanup()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -42,6 +42,7 @@ type Segments struct {
 	Effort        bool   `mapstructure:"effort"`
 	Thinking      bool   `mapstructure:"thinking"`
 	FastMode      bool   `mapstructure:"fast_mode"`
+	Repo          bool   `mapstructure:"repo"`
 	Worktree      bool   `mapstructure:"worktree"`
 	Cost          string `mapstructure:"cost"`
 	Status        bool   `mapstructure:"status"`
@@ -74,6 +75,7 @@ func Defaults() Config {
 			Effort:      true,
 			Thinking:    true,
 			FastMode:    true,
+			Repo:        true,
 			Worktree:    true,
 			Cost:        CostAuto,
 			Status:      true,
@@ -133,6 +135,7 @@ var knownKeys = map[string]bool{
 	"segments.effort":          true,
 	"segments.thinking":        true,
 	"segments.fast_mode":       true,
+	"segments.repo":            true,
 	"segments.worktree":        true,
 	"segments.cost":            true,
 	"segments.status":          true,
@@ -202,6 +205,7 @@ func validateSegments(seg *Segments, v *viper.Viper) []string {
 		{"segments.effort", v.Get("segments.effort")},
 		{"segments.thinking", v.Get("segments.thinking")},
 		{"segments.fast_mode", v.Get("segments.fast_mode")},
+		{"segments.repo", v.Get("segments.repo")},
 		{"segments.worktree", v.Get("segments.worktree")},
 		{"segments.status", v.Get("segments.status")},
 		{"segments.context", v.Get("segments.context")},
@@ -250,6 +254,7 @@ func setViperDefaults(viperInstance *viper.Viper) {
 	viperInstance.SetDefault("segments.effort", true)
 	viperInstance.SetDefault("segments.thinking", true)
 	viperInstance.SetDefault("segments.fast_mode", true)
+	viperInstance.SetDefault("segments.repo", true)
 	viperInstance.SetDefault("segments.worktree", true)
 	viperInstance.SetDefault("segments.cost", CostAuto)
 	viperInstance.SetDefault("segments.status", true)


### PR DESCRIPTION
## What's New

Combined repo/PR/worktree segment driven by the new `workspace.repo` and top-level `pr` fields Claude Code 2.1.145+ now sends to the statusline.

### Example

```text
🐙 lexfrei/claudeline #19 📝 @ feat-api
```

Replaces the standalone `🌿 feat-api` worktree segment whenever repository information is available. When `workspace.repo` is absent (non-git directory, detached state), the segment falls back to the existing bare `🌿 branch` form.

### Components

  - Host icon — `🐙` github.com, `🦊` gitlab.com, `🪣` bitbucket.org, `📦` for unknown hosts (with `host/` prefix to keep the source legible).
  - `owner/name` — always shown.
  - `#N <state>` — when an open PR is detected. Review state icons: `📝` draft, `👀` pending, `💬` commented, `🔴` changes_requested, `✅` approved. Unknown states omit the icon.
  - `@ worktree` — appended when inside a linked worktree.

### Config

```toml
[segments]
repo = true       # default — combined segment
worktree = true   # bare worktree fallback when repo info absent
```

CLI flags: `--no-repo`, `--no-worktree`.

## Why

The original `🌿` segment showed only the branch name. The combined form surfaces the repository and any open PR in the same slot, which closes the "what am I working on right now" question at a glance without opening `gh pr list` or `git remote -v`. Backwards-compatible: clients on older Claude Code versions (without `workspace.repo`) see the same `🌿 branch` segment as before.

## Notes

  - Closes the "GitHub repo + PR info" half of #15 (the other half — fully customizable symbols — remains).
  - Empirically verified against a real draft PR — `pr.review_state` is `draft`; other possible values are inferred from GitHub's review API vocabulary (`approved`, `changes_requested`, `commented`, `pending`). Unknown values are rendered without an icon.
  - README documents both the new segment and the previously-undocumented effort/thinking/fast-mode model indicators that landed in v1.2.0.
