### PR TITLE
feat(statusline): show current branch in repo and worktree segments

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ Renders when Claude Code reports `workspace.repo` (a git remote pointing at a kn
 
   - `🐙` github.com, `🦊` gitlab.com, `🪣` bitbucket.org, `📦` other hosts (with `host/` prefix)
   - `#N` followed by review state: `📝` draft, `👀` pending, `💬` commented, `🔴` changes requested, `✅` approved
-  - `@ branch` when inside a linked worktree
+  - `@ branch` — current branch read directly from `cwd/.git/HEAD`, or the linked-worktree name when HEAD is detached or unreadable
 
-When no `workspace.repo` is present (non-git or detached state), the segment falls back to the bare worktree form (`🌿 branch`).
+When no `workspace.repo` is present (non-git directory), the segment falls back to the bare worktree form (`🌿 branch`) showing the same branch source.
 
 Quota indicators compare your usage rate against elapsed time to warn about hitting limits:
 
@@ -71,6 +71,7 @@ Disable with `--no-offpeak` or `offpeak = false` in config.
 - Claude Code v2.1.97+ recommended (adds `workspace.git_worktree` and `refreshInterval`)
 - Claude Code v2.1.119+ enables effort, thinking, and fast-mode indicators
 - Claude Code v2.1.145+ enables the combined repo / PR segment
+- Current branch in `@ branch` is read directly from `cwd/.git/HEAD`, no `git` binary required
 
 ## Installation
 

--- a/cmd/claudeline/main.go
+++ b/cmd/claudeline/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/lexfrei/claudeline/internal/compaction"
 	"github.com/lexfrei/claudeline/internal/config"
 	"github.com/lexfrei/claudeline/internal/fmtutil"
+	"github.com/lexfrei/claudeline/internal/gitinfo"
 	"github.com/lexfrei/claudeline/internal/promotion"
 	"github.com/lexfrei/claudeline/internal/status"
 	"github.com/lexfrei/claudeline/internal/usage"
@@ -59,8 +60,10 @@ type stdinData struct {
 	Thinking struct {
 		Enabled bool `json:"enabled"`
 	} `json:"thinking"`
-	FastMode  bool `json:"fast_mode"` //nolint:tagliatelle // External API format
+	FastMode  bool   `json:"fast_mode"` //nolint:tagliatelle // External API format
+	Cwd       string `json:"cwd"`
 	Workspace struct {
+		CurrentDir  string         `json:"current_dir"`  //nolint:tagliatelle // External API format
 		GitWorktree string         `json:"git_worktree"` //nolint:tagliatelle // External API format
 		Repo        *stdinRepoInfo `json:"repo"`
 	} `json:"workspace"`
@@ -285,11 +288,33 @@ func appendRepoSegment(segments []string, data *stdinData, cfg *config.Config) [
 		return append(segments, formatRepoSegment(data))
 	}
 
-	if cfg.Segments.Worktree && data.Workspace.GitWorktree != "" {
-		return append(segments, "🌿 "+data.Workspace.GitWorktree)
+	if cfg.Segments.Worktree {
+		if branch := branchOrWorktree(data); branch != "" {
+			return append(segments, "🌿 "+branch)
+		}
 	}
 
 	return segments
+}
+
+// branchOrWorktree returns the current branch read from .git/HEAD, or falls
+// back to workspace.git_worktree when the branch cannot be determined
+// (detached HEAD, unreadable repo, non-git cwd).
+func branchOrWorktree(data *stdinData) string {
+	if branch := gitinfo.CurrentBranch(resolveCwd(data)); branch != "" {
+		return branch
+	}
+
+	return data.Workspace.GitWorktree
+}
+
+// resolveCwd picks the most specific cwd value Claude Code provides.
+func resolveCwd(data *stdinData) string {
+	if data.Workspace.CurrentDir != "" {
+		return data.Workspace.CurrentDir
+	}
+
+	return data.Cwd
 }
 
 // formatRepoSegment builds the combined repo segment:
@@ -313,8 +338,8 @@ func formatRepoSegment(data *stdinData) string {
 		parts = append(parts, prPart)
 	}
 
-	if data.Workspace.GitWorktree != "" {
-		parts = append(parts, "@ "+data.Workspace.GitWorktree)
+	if branch := branchOrWorktree(data); branch != "" {
+		parts = append(parts, "@ "+branch)
 	}
 
 	return strings.Join(parts, " ")

--- a/cmd/claudeline/main_test.go
+++ b/cmd/claudeline/main_test.go
@@ -368,6 +368,119 @@ func TestBuildStatuslineRepoDisabledFallsBackToWorktree(t *testing.T) {
 	}
 }
 
+func TestBuildStatuslineRepoSegmentUsesBranchFromCwd(t *testing.T) {
+	cleanup := setupTestEnv(t)
+	defer cleanup()
+
+	status.HTTPGetFn = failHTTP
+
+	dir := t.TempDir()
+	gitDir := filepath.Join(dir, ".git")
+
+	if err := os.MkdirAll(gitDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(filepath.Join(gitDir, "HEAD"), []byte("ref: refs/heads/feat/from-head\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	input := fmt.Sprintf(
+		`{"workspace":{"current_dir":%q,"repo":{"host":"github.com","owner":"o","name":"r"}}}`,
+		dir,
+	)
+
+	got := buildStatusline([]byte(input), defaultCfg())
+	if !strings.Contains(got, "🐙 o/r @ feat/from-head") {
+		t.Errorf("expected branch from .git/HEAD, got %q", got)
+	}
+}
+
+func TestBuildStatuslineRepoSegmentBranchPrefersOverWorktreeName(t *testing.T) {
+	cleanup := setupTestEnv(t)
+	defer cleanup()
+
+	status.HTTPGetFn = failHTTP
+
+	dir := t.TempDir()
+	gitDir := filepath.Join(dir, ".git")
+
+	if err := os.MkdirAll(gitDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(filepath.Join(gitDir, "HEAD"), []byte("ref: refs/heads/feat/from-head\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Both `git_worktree` and a readable HEAD are present — branch wins.
+	input := fmt.Sprintf(
+		`{"workspace":{"current_dir":%q,"git_worktree":"side","repo":{"host":"github.com","owner":"o","name":"r"}}}`,
+		dir,
+	)
+
+	got := buildStatusline([]byte(input), defaultCfg())
+	if !strings.Contains(got, "🐙 o/r @ feat/from-head") {
+		t.Errorf("expected branch to win over worktree name, got %q", got)
+	}
+}
+
+func TestBuildStatuslineRepoSegmentFallsBackToWorktreeNameWhenDetached(t *testing.T) {
+	cleanup := setupTestEnv(t)
+	defer cleanup()
+
+	status.HTTPGetFn = failHTTP
+
+	dir := t.TempDir()
+	gitDir := filepath.Join(dir, ".git")
+
+	if err := os.MkdirAll(gitDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Detached HEAD — gitinfo returns empty, so we fall back to git_worktree.
+	if err := os.WriteFile(filepath.Join(gitDir, "HEAD"), []byte("3a7c2f1e0d8b9f4a5c6e7d8b9f4a5c6e7d8b9f4a\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	input := fmt.Sprintf(
+		`{"workspace":{"current_dir":%q,"git_worktree":"side","repo":{"host":"github.com","owner":"o","name":"r"}}}`,
+		dir,
+	)
+
+	got := buildStatusline([]byte(input), defaultCfg())
+	if !strings.Contains(got, "🐙 o/r @ side") {
+		t.Errorf("expected fallback to worktree name on detached HEAD, got %q", got)
+	}
+}
+
+func TestBuildStatuslineBareWorktreeSegmentShowsBranch(t *testing.T) {
+	cleanup := setupTestEnv(t)
+	defer cleanup()
+
+	status.HTTPGetFn = failHTTP
+
+	dir := t.TempDir()
+	gitDir := filepath.Join(dir, ".git")
+
+	if err := os.MkdirAll(gitDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(filepath.Join(gitDir, "HEAD"), []byte("ref: refs/heads/feat/bare\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// No workspace.repo — falls back to bare worktree segment, but now shows
+	// the branch read from cwd's .git/HEAD instead of being empty.
+	input := fmt.Sprintf(`{"workspace":{"current_dir":%q}}`, dir)
+
+	got := buildStatusline([]byte(input), defaultCfg())
+	if !strings.Contains(got, "🌿 feat/bare") {
+		t.Errorf("expected bare worktree segment with branch from HEAD, got %q", got)
+	}
+}
+
 func TestBuildStatuslineBothRepoAndWorktreeDisabled(t *testing.T) {
 	cleanup := setupTestEnv(t)
 	defer cleanup()

--- a/internal/gitinfo/branch.go
+++ b/internal/gitinfo/branch.go
@@ -1,0 +1,76 @@
+// Package gitinfo reads minimal git metadata from the working tree without
+// shelling out — only the files needed to identify the current branch.
+package gitinfo
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const headRefPrefix = "ref: refs/heads/"
+
+// CurrentBranch returns the branch name at HEAD for the given working directory.
+// Returns an empty string when:
+//
+//   - cwd is empty or not inside a git repository
+//   - HEAD is detached (no symbolic ref)
+//   - any required file is unreadable
+//
+// Supports both regular repos (.git is a directory) and linked worktrees
+// (.git is a file pointing to gitdir).
+func CurrentBranch(cwd string) string {
+	if cwd == "" {
+		return ""
+	}
+
+	headPath, ok := resolveHeadPath(cwd)
+	if !ok {
+		return ""
+	}
+
+	content, err := os.ReadFile(headPath)
+	if err != nil {
+		return ""
+	}
+
+	line := strings.TrimSpace(string(content))
+	if !strings.HasPrefix(line, headRefPrefix) {
+		return ""
+	}
+
+	return strings.TrimPrefix(line, headRefPrefix)
+}
+
+func resolveHeadPath(cwd string) (string, bool) {
+	gitPath := filepath.Join(cwd, ".git")
+
+	info, err := os.Stat(gitPath)
+	if err != nil {
+		return "", false
+	}
+
+	if info.IsDir() {
+		return filepath.Join(gitPath, "HEAD"), true
+	}
+
+	// Linked worktree: .git is a file containing "gitdir: <path>".
+	content, err := os.ReadFile(gitPath)
+	if err != nil {
+		return "", false
+	}
+
+	line := strings.TrimSpace(string(content))
+
+	const gitdirPrefix = "gitdir: "
+	if !strings.HasPrefix(line, gitdirPrefix) {
+		return "", false
+	}
+
+	gitdir := strings.TrimPrefix(line, gitdirPrefix)
+	if !filepath.IsAbs(gitdir) {
+		gitdir = filepath.Join(cwd, gitdir)
+	}
+
+	return filepath.Join(gitdir, "HEAD"), true
+}

--- a/internal/gitinfo/branch_test.go
+++ b/internal/gitinfo/branch_test.go
@@ -1,0 +1,141 @@
+package gitinfo
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCurrentBranchEmptyCwd(t *testing.T) {
+	t.Parallel()
+
+	if got := CurrentBranch(""); got != "" {
+		t.Errorf("expected empty branch for empty cwd, got %q", got)
+	}
+}
+
+func TestCurrentBranchNotAGitRepo(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	if got := CurrentBranch(dir); got != "" {
+		t.Errorf("expected empty branch outside a repo, got %q", got)
+	}
+}
+
+func TestCurrentBranchRegularRepo(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	gitDir := filepath.Join(dir, ".git")
+
+	if err := os.MkdirAll(gitDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(filepath.Join(gitDir, "HEAD"), []byte("ref: refs/heads/feat/foo\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := CurrentBranch(dir); got != "feat/foo" {
+		t.Errorf("expected feat/foo, got %q", got)
+	}
+}
+
+func TestCurrentBranchDetachedHead(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	gitDir := filepath.Join(dir, ".git")
+
+	if err := os.MkdirAll(gitDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Detached HEAD points at a commit SHA, not a ref.
+	if err := os.WriteFile(filepath.Join(gitDir, "HEAD"), []byte("3a7c2f1e0d8b9f4a5c6e7d8b9f4a5c6e7d8b9f4a\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := CurrentBranch(dir); got != "" {
+		t.Errorf("expected empty branch on detached HEAD, got %q", got)
+	}
+}
+
+func TestCurrentBranchLinkedWorktreeAbsoluteGitdir(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	mainGit := filepath.Join(root, "main", ".git")
+	worktreeGitdir := filepath.Join(mainGit, "worktrees", "side")
+	worktreeDir := filepath.Join(root, "side")
+
+	if err := os.MkdirAll(worktreeGitdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.MkdirAll(worktreeDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(filepath.Join(worktreeGitdir, "HEAD"), []byte("ref: refs/heads/feat/side\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(filepath.Join(worktreeDir, ".git"), []byte("gitdir: "+worktreeGitdir+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := CurrentBranch(worktreeDir); got != "feat/side" {
+		t.Errorf("expected feat/side, got %q", got)
+	}
+}
+
+func TestCurrentBranchLinkedWorktreeRelativeGitdir(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	mainGit := filepath.Join(root, "main", ".git")
+	worktreeGitdir := filepath.Join(mainGit, "worktrees", "side")
+	worktreeDir := filepath.Join(root, "side")
+
+	if err := os.MkdirAll(worktreeGitdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.MkdirAll(worktreeDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(filepath.Join(worktreeGitdir, "HEAD"), []byte("ref: refs/heads/feat/rel\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	relGitdir, err := filepath.Rel(worktreeDir, worktreeGitdir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(filepath.Join(worktreeDir, ".git"), []byte("gitdir: "+relGitdir+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := CurrentBranch(worktreeDir); got != "feat/rel" {
+		t.Errorf("expected feat/rel, got %q", got)
+	}
+}
+
+func TestCurrentBranchMalformedGitFile(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(dir, ".git"), []byte("not a gitdir pointer\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := CurrentBranch(dir); got != "" {
+		t.Errorf("expected empty branch for malformed .git file, got %q", got)
+	}
+}


### PR DESCRIPTION
## What's New

Show the actual git branch in the repo / worktree segment by reading `cwd/.git/HEAD` directly. No `git` fork-exec, no extra dependencies.

### Example

```text
🐙 lexfrei/claudeline #19 📝 @ feat/current-branch
🌿 feat/current-branch
```

Previously the `@ name` suffix used `workspace.git_worktree`, which is empty in regular checkouts (not inside `git worktree add`). The bare `🌿` fallback had the same limitation. Now both pick up the live branch from `cwd/.git/HEAD`.

### Branch resolution

  - Regular repo (`.git` is a directory) — reads `.git/HEAD`.
  - Linked worktree (`.git` is a file with `gitdir: <path>`) — resolves to the linked gitdir's HEAD, absolute or relative paths.
  - Detached HEAD, malformed metadata, non-git directory, or any read error — returns empty so the segment can fall back to `workspace.git_worktree`.

Cost is one file `stat` plus one `ReadFile` per render — negligible at the default `refreshInterval: 5s`.

### stdin schema

Added two fields populated by every recent Claude Code version:

  - `cwd` (top-level)
  - `workspace.current_dir`

claudeline prefers `workspace.current_dir`, falls back to top-level `cwd`.

## Why

The previous `@ name` only worked inside linked worktrees. Most users run from a regular checkout where the suffix was always empty — so the segment communicated only `owner/name` and PR info, hiding the most useful "what am I editing right now" bit.

## Notes

  - New `internal/gitinfo` package keeps HEAD parsing isolated and testable. Covered: regular repo, detached HEAD, linked worktree with absolute and relative `gitdir`, malformed `.git` file, missing repo.
  - No new config — branch resolution is automatic when the segment renders.
