### PR TITLE
docs(readme): fix Go version badge URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # claudeline
 
 [![CI](https://github.com/lexfrei/claudeline/actions/workflows/ci.yaml/badge.svg)](https://github.com/lexfrei/claudeline/actions/workflows/ci.yaml)
-[![Go](https://img.shields.io/github/go-mod-go-version/lexfrei/claudeline)](https://go.dev/)
+[![Go](https://img.shields.io/github/go-mod/go-version/lexfrei/claudeline)](https://go.dev/)
 [![License](https://img.shields.io/github/license/lexfrei/claudeline)](LICENSE)
 
 Real-time statusline for [Claude Code](https://docs.anthropic.com/en/docs/claude-code) showing live quota usage directly from stdin data.


### PR DESCRIPTION
## Problem

The Go version badge in README has been silently broken — shields.io retired the dashed `github/go-mod-go-version/...` endpoint, which now returns:

```json
{"label": "404", "message": "badge not found", "color": "red"}
```

## Fix

Switch to the current endpoint `github/go-mod/go-version/...` (slashes instead of dashes). Tested locally:

```bash
$ curl -s https://img.shields.io/github/go-mod/go-version/lexfrei/claudeline.json
{"label":"Go","message":"v1.26","color":"blue",...}
```

Badge will now render the actual Go version pinned in `go.mod`.
