### PR TITLE
feat(statusline): show linked worktree name alongside branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Real-time statusline for [Claude Code](https://docs.anthropic.com/en/docs/claude
 ## Example output
 
 ```text
-🤖 Opus 4.7 ⏫💭 | 🧠 67% | 🔄 2 | 🟡 7d: 42% (4d 2h) | 🔴 5h: 91% (27m) | 🐙 lexfrei/claudeline #19 📝 @ feat-api
+🤖 Opus 4.7 ⏫💭 | 🧠 67% | 🔄 2 | 🟡 7d: 42% (4d 2h) | 🔴 5h: 91% (27m) | 🐙 lexfrei/claudeline #19 📝 🌳 feat-api 🌿 feat/api
 ```
 
 ## Segments
@@ -17,8 +17,8 @@ Real-time statusline for [Claude Code](https://docs.anthropic.com/en/docs/claude
 | Segment | Description |
 | --- | --- |
 | 🤖 Model | Active model name, with effort / thinking / fast-mode indicators (Claude Code v2.1.119+) |
-| 🐙 Repo | Repository host icon, `owner/name`, optional `#PR <state>`, optional `@ worktree` (Claude Code v2.1.145+) |
-| 🌿 Worktree | Bare worktree fallback when no repository info is available |
+| 🐙 Repo | Repository host icon, `owner/name`, optional `#PR <state>`, optional `🌳 worktree` (linked worktrees only) and `🌿 branch` (Claude Code v2.1.145+) |
+| 🌳 Worktree / 🌿 Branch | Linked-worktree directory name and current branch; branch alone falls back here when no repository info is available |
 | 💰 Cost | Cumulative session cost in USD (hidden by default for subscribers, see [Cost mode](#cost-mode)) |
 | ⚠️/🔶/🔴 Status | Anthropic platform status: ⚠️ degraded, 🔶 major outage, 🔴 critical (hidden when all clear) |
 | 🧠 Context | Context window usage percentage (color-coded) |
@@ -38,9 +38,10 @@ Renders when Claude Code reports `workspace.repo` (a git remote pointing at a kn
 
   - `🐙` github.com, `🦊` gitlab.com, `🪣` bitbucket.org, `📦` other hosts (with `host/` prefix)
   - `#N` followed by review state: `📝` draft, `👀` pending, `💬` commented, `🔴` changes requested, `✅` approved
-  - `@ branch` — current branch read directly from `cwd/.git/HEAD`, or the linked-worktree name when HEAD is detached or unreadable
+  - `🌳 worktree` — directory name of the linked worktree, shown only when `cwd` is a linked worktree (in the main clone it would just duplicate the repo name, so it is omitted)
+  - `🌿 branch` — current branch read directly from `cwd/.git/HEAD`; when HEAD is detached or unreadable it falls back to the worktree name from stdin, but only if the `🌳` marker is not already shown (so the same name is never printed twice)
 
-When no `workspace.repo` is present (non-git directory), the segment falls back to the bare worktree form (`🌿 branch`) showing the same branch source.
+When no `workspace.repo` is present (non-git directory), the segment falls back to the bare `🌳 worktree 🌿 branch` form showing the same sources.
 
 Quota indicators compare your usage rate against elapsed time to warn about hitting limits:
 
@@ -71,7 +72,7 @@ Disable with `--no-offpeak` or `offpeak = false` in config.
 - Claude Code v2.1.97+ recommended (adds `workspace.git_worktree` and `refreshInterval`)
 - Claude Code v2.1.119+ enables effort, thinking, and fast-mode indicators
 - Claude Code v2.1.145+ enables the combined repo / PR segment
-- Current branch in `@ branch` is read directly from `cwd/.git/HEAD`, no `git` binary required
+- Current branch in `🌿 branch` is read directly from `cwd/.git/HEAD`, no `git` binary required
 
 ## Installation
 

--- a/cmd/claudeline/main.go
+++ b/cmd/claudeline/main.go
@@ -282,30 +282,51 @@ func buildStatusline(raw []byte, cfg *config.Config) string {
 }
 
 // appendRepoSegment renders the combined repo/PR/worktree segment, or falls
-// back to the bare worktree segment when no repo info is available.
+// back to a bare "🌳 worktree 🌿 branch" segment when no repo info is available.
 func appendRepoSegment(segments []string, data *stdinData, cfg *config.Config) []string {
 	if cfg.Segments.Repo && data.Workspace.Repo != nil {
 		return append(segments, formatRepoSegment(data))
 	}
 
 	if cfg.Segments.Worktree {
-		if branch := branchOrWorktree(data); branch != "" {
-			return append(segments, "🌿 "+branch)
+		if parts := worktreeBranchParts(data); len(parts) > 0 {
+			return append(segments, strings.Join(parts, " "))
 		}
 	}
 
 	return segments
 }
 
-// branchOrWorktree returns the current branch read from .git/HEAD, or falls
-// back to workspace.git_worktree when the branch cannot be determined
-// (detached HEAD, unreadable repo, non-git cwd).
-func branchOrWorktree(data *stdinData) string {
-	if branch := gitinfo.CurrentBranch(resolveCwd(data)); branch != "" {
-		return branch
+// worktreeBranchParts returns the display parts identifying where work happens:
+// "🌳 <name>" when cwd is a linked worktree, and "🌿 <branch>" for the current
+// branch read from cwd/.git/HEAD. Either part may be absent.
+//
+// The same name is never printed under both markers. In the main clone the
+// worktree marker is omitted (the name would just duplicate the repo name). When
+// a linked worktree's branch equals its directory name — the common
+// `git worktree add ../feat-x feat-x` pattern — the branch marker is dropped
+// since 🌳 already shows it. And when HEAD carries no branch (detached or
+// unreadable), the branch marker falls back to the stdin worktree name only if
+// no 🌳 marker is already shown.
+func worktreeBranchParts(data *stdinData) []string {
+	cwd := resolveCwd(data)
+	worktree := gitinfo.LinkedWorktreeName(cwd)
+	branch := gitinfo.CurrentBranch(cwd)
+
+	var parts []string
+
+	if worktree != "" {
+		parts = append(parts, "🌳 "+worktree)
 	}
 
-	return data.Workspace.GitWorktree
+	switch {
+	case branch != "" && branch != worktree:
+		parts = append(parts, "🌿 "+branch)
+	case branch == "" && worktree == "" && data.Workspace.GitWorktree != "":
+		parts = append(parts, "🌿 "+data.Workspace.GitWorktree)
+	}
+
+	return parts
 }
 
 // resolveCwd picks the most specific cwd value Claude Code provides.
@@ -319,10 +340,11 @@ func resolveCwd(data *stdinData) string {
 
 // formatRepoSegment builds the combined repo segment:
 //
-//	🐙 owner/repo [#N <state>] [@ worktree]
+//	🐙 owner/repo [#N <state>] [🌳 worktree] [🌿 branch]
 //
 // Host icon varies by `workspace.repo.host`; unknown hosts surface as
-// "📦 host/owner/repo" so the source is still legible.
+// "📦 host/owner/repo" so the source is still legible. The 🌳 worktree marker
+// appears only inside a linked worktree.
 func formatRepoSegment(data *stdinData) string {
 	repo := data.Workspace.Repo
 	icon, prefix := repoHostIcon(repo.Host)
@@ -338,9 +360,7 @@ func formatRepoSegment(data *stdinData) string {
 		parts = append(parts, prPart)
 	}
 
-	if branch := branchOrWorktree(data); branch != "" {
-		parts = append(parts, "@ "+branch)
-	}
+	parts = append(parts, worktreeBranchParts(data)...)
 
 	return strings.Join(parts, " ")
 }

--- a/cmd/claudeline/main_test.go
+++ b/cmd/claudeline/main_test.go
@@ -267,9 +267,9 @@ func TestBuildStatuslineRepoSegment(t *testing.T) {
 			expected: "🐙 lexfrei/claudeline",
 		},
 		{
-			name:     "github repo with worktree",
+			name:     "github repo with branch fallback",
 			input:    `{"workspace":{"repo":{"host":"github.com","owner":"lexfrei","name":"claudeline"},"git_worktree":"feat-api"}}`,
-			expected: "🐙 lexfrei/claudeline @ feat-api",
+			expected: "🐙 lexfrei/claudeline 🌿 feat-api",
 		},
 		{
 			name:     "github repo with draft PR",
@@ -277,9 +277,9 @@ func TestBuildStatuslineRepoSegment(t *testing.T) {
 			expected: "🐙 lexfrei/claudeline #19 📝",
 		},
 		{
-			name:     "github repo with approved PR and worktree",
+			name:     "github repo with approved PR and branch",
 			input:    `{"workspace":{"repo":{"host":"github.com","owner":"lexfrei","name":"claudeline"},"git_worktree":"feat-api"},"pr":{"number":42,"review_state":"approved"}}`,
-			expected: "🐙 lexfrei/claudeline #42 ✅ @ feat-api",
+			expected: "🐙 lexfrei/claudeline #42 ✅ 🌿 feat-api",
 		},
 		{
 			name:     "changes_requested",
@@ -391,7 +391,7 @@ func TestBuildStatuslineRepoSegmentUsesBranchFromCwd(t *testing.T) {
 	)
 
 	got := buildStatusline([]byte(input), defaultCfg())
-	if !strings.Contains(got, "🐙 o/r @ feat/from-head") {
+	if !strings.Contains(got, "🐙 o/r 🌿 feat/from-head") {
 		t.Errorf("expected branch from .git/HEAD, got %q", got)
 	}
 }
@@ -420,8 +420,140 @@ func TestBuildStatuslineRepoSegmentBranchPrefersOverWorktreeName(t *testing.T) {
 	)
 
 	got := buildStatusline([]byte(input), defaultCfg())
-	if !strings.Contains(got, "🐙 o/r @ feat/from-head") {
+	if !strings.Contains(got, "🐙 o/r 🌿 feat/from-head") {
 		t.Errorf("expected branch to win over worktree name, got %q", got)
+	}
+}
+
+func TestBuildStatuslineRepoSegmentShowsLinkedWorktreeAndBranch(t *testing.T) {
+	cleanup := setupTestEnv(t)
+	defer cleanup()
+
+	status.HTTPGetFn = failHTTP
+
+	root := t.TempDir()
+	worktreeGitdir := filepath.Join(root, "main", ".git", "worktrees", "side")
+	worktreeDir := filepath.Join(root, "side")
+
+	if err := os.MkdirAll(worktreeGitdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.MkdirAll(worktreeDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(filepath.Join(worktreeGitdir, "HEAD"), []byte("ref: refs/heads/feat/side\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(filepath.Join(worktreeDir, ".git"), []byte("gitdir: "+worktreeGitdir+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Inside a linked worktree both markers appear: 🌳 worktree dir name, then
+	// 🌿 branch from its HEAD.
+	input := fmt.Sprintf(
+		`{"workspace":{"current_dir":%q,"repo":{"host":"github.com","owner":"o","name":"r"}}}`,
+		worktreeDir,
+	)
+
+	got := buildStatusline([]byte(input), defaultCfg())
+	if !strings.Contains(got, "🐙 o/r 🌳 side 🌿 feat/side") {
+		t.Errorf("expected linked worktree and branch markers, got %q", got)
+	}
+}
+
+func TestBuildStatuslineLinkedWorktreeBranchEqualsDirShowsNoDuplicate(t *testing.T) {
+	cleanup := setupTestEnv(t)
+	defer cleanup()
+
+	status.HTTPGetFn = failHTTP
+
+	root := t.TempDir()
+	worktreeGitdir := filepath.Join(root, "main", ".git", "worktrees", "side")
+	worktreeDir := filepath.Join(root, "side")
+
+	if err := os.MkdirAll(worktreeGitdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.MkdirAll(worktreeDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// The common `git worktree add ../side side` pattern: the worktree dir name
+	// and the branch are both "side". The branch marker must be dropped so the
+	// name is not printed twice (🌳 already shows it).
+	if err := os.WriteFile(filepath.Join(worktreeGitdir, "HEAD"), []byte("ref: refs/heads/side\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(filepath.Join(worktreeDir, ".git"), []byte("gitdir: "+worktreeGitdir+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	input := fmt.Sprintf(
+		`{"workspace":{"current_dir":%q,"repo":{"host":"github.com","owner":"o","name":"r"}}}`,
+		worktreeDir,
+	)
+
+	got := buildStatusline([]byte(input), defaultCfg())
+	if !strings.Contains(got, "🐙 o/r 🌳 side") {
+		t.Errorf("expected worktree marker, got %q", got)
+	}
+
+	if strings.Contains(got, "🌿") {
+		t.Errorf("expected no branch marker when branch equals worktree dir name, got %q", got)
+	}
+
+	if n := strings.Count(got, "side"); n != 1 {
+		t.Errorf("expected the worktree name to appear exactly once, got %d in %q", n, got)
+	}
+}
+
+func TestBuildStatuslineLinkedWorktreeDetachedHeadShowsNoDuplicate(t *testing.T) {
+	cleanup := setupTestEnv(t)
+	defer cleanup()
+
+	status.HTTPGetFn = failHTTP
+
+	root := t.TempDir()
+	worktreeGitdir := filepath.Join(root, "main", ".git", "worktrees", "side")
+	worktreeDir := filepath.Join(root, "side")
+
+	if err := os.MkdirAll(worktreeGitdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.MkdirAll(worktreeDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Detached HEAD inside a linked worktree: HEAD is a SHA, not a ref.
+	if err := os.WriteFile(filepath.Join(worktreeGitdir, "HEAD"), []byte("3a7c2f1e0d8b9f4a5c6e7d8b9f4a5c6e7d8b9f4a\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(filepath.Join(worktreeDir, ".git"), []byte("gitdir: "+worktreeGitdir+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Claude Code's git_worktree equals the worktree dir name. The branch
+	// marker must NOT fall back to it here — that would duplicate "side" under
+	// both 🌳 and 🌿. Only the 🌳 marker is shown; there is no branch.
+	input := fmt.Sprintf(
+		`{"workspace":{"current_dir":%q,"git_worktree":"side","repo":{"host":"github.com","owner":"o","name":"r"}}}`,
+		worktreeDir,
+	)
+
+	got := buildStatusline([]byte(input), defaultCfg())
+	if !strings.Contains(got, "🐙 o/r 🌳 side") {
+		t.Errorf("expected worktree marker, got %q", got)
+	}
+
+	if strings.Contains(got, "🌿") {
+		t.Errorf("expected no branch marker on detached HEAD in a linked worktree, got %q", got)
 	}
 }
 
@@ -449,7 +581,7 @@ func TestBuildStatuslineRepoSegmentFallsBackToWorktreeNameWhenDetached(t *testin
 	)
 
 	got := buildStatusline([]byte(input), defaultCfg())
-	if !strings.Contains(got, "🐙 o/r @ side") {
+	if !strings.Contains(got, "🐙 o/r 🌿 side") {
 		t.Errorf("expected fallback to worktree name on detached HEAD, got %q", got)
 	}
 }

--- a/internal/gitinfo/branch.go
+++ b/internal/gitinfo/branch.go
@@ -43,34 +43,48 @@ func CurrentBranch(cwd string) string {
 }
 
 func resolveHeadPath(cwd string) (string, bool) {
+	gitDir, _, ok := resolveGitDir(cwd)
+	if !ok {
+		return "", false
+	}
+
+	return filepath.Join(gitDir, "HEAD"), true
+}
+
+// resolveGitDir returns the git directory that backs cwd and whether cwd is a
+// linked worktree. A regular repo has a .git directory and reports linked=false;
+// a linked worktree has a .git *file* containing "gitdir: <path>" and reports
+// linked=true. ok is false when cwd is not inside a git repository or the
+// pointer file is unreadable or malformed.
+func resolveGitDir(cwd string) (gitDir string, linked, ok bool) {
 	gitPath := filepath.Join(cwd, ".git")
 
 	info, err := os.Stat(gitPath)
 	if err != nil {
-		return "", false
+		return "", false, false
 	}
 
 	if info.IsDir() {
-		return filepath.Join(gitPath, "HEAD"), true
+		return gitPath, false, true
 	}
 
 	// Linked worktree: .git is a file containing "gitdir: <path>".
 	content, err := os.ReadFile(gitPath)
 	if err != nil {
-		return "", false
+		return "", false, false
 	}
 
 	line := strings.TrimSpace(string(content))
 
 	const gitdirPrefix = "gitdir: "
 	if !strings.HasPrefix(line, gitdirPrefix) {
-		return "", false
+		return "", false, false
 	}
 
-	gitdir := strings.TrimPrefix(line, gitdirPrefix)
-	if !filepath.IsAbs(gitdir) {
-		gitdir = filepath.Join(cwd, gitdir)
+	gitDir = strings.TrimPrefix(line, gitdirPrefix)
+	if !filepath.IsAbs(gitDir) {
+		gitDir = filepath.Join(cwd, gitDir)
 	}
 
-	return filepath.Join(gitdir, "HEAD"), true
+	return gitDir, true, true
 }

--- a/internal/gitinfo/worktree.go
+++ b/internal/gitinfo/worktree.go
@@ -1,0 +1,39 @@
+package gitinfo
+
+import "path/filepath"
+
+// worktreesDir is the directory under a repo's git dir that holds linked
+// worktree metadata: "<main>/.git/worktrees/<name>".
+const worktreesDir = "worktrees"
+
+// LinkedWorktreeName returns the directory name of the linked worktree that cwd
+// belongs to, or an empty string when:
+//
+//   - cwd is empty or not inside a git repository
+//   - cwd is the main clone (.git is a directory, not a pointer file)
+//   - the .git pointer does not resolve to "<main>/.git/worktrees/<name>"
+//
+// The name is the final path element of cwd — the worktree's on-disk root, the
+// name the user actually sees. The git metadata dir basename is not used: git
+// disambiguates colliding metadata dirs (worktrees/side, worktrees/side1) while
+// the on-disk directories keep their original name. A non-empty result is only
+// possible when cwd itself holds the .git pointer (resolveGitDir reads cwd/.git),
+// so cwd is always the worktree root here.
+func LinkedWorktreeName(cwd string) string {
+	if cwd == "" {
+		return ""
+	}
+
+	gitDir, linked, ok := resolveGitDir(cwd)
+	if !ok || !linked {
+		return ""
+	}
+
+	// Expect ".../worktrees/<name>"; guard against unexpected layouts so a
+	// stray .git pointer is never surfaced as a worktree name.
+	if filepath.Base(filepath.Dir(gitDir)) != worktreesDir {
+		return ""
+	}
+
+	return filepath.Base(cwd)
+}

--- a/internal/gitinfo/worktree_test.go
+++ b/internal/gitinfo/worktree_test.go
@@ -1,0 +1,164 @@
+package gitinfo
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLinkedWorktreeNameEmptyCwd(t *testing.T) {
+	t.Parallel()
+
+	if got := LinkedWorktreeName(""); got != "" {
+		t.Errorf("expected empty worktree name for empty cwd, got %q", got)
+	}
+}
+
+func TestLinkedWorktreeNameNotAGitRepo(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	if got := LinkedWorktreeName(dir); got != "" {
+		t.Errorf("expected empty worktree name outside a repo, got %q", got)
+	}
+}
+
+func TestLinkedWorktreeNameMainClone(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	gitDir := filepath.Join(dir, ".git")
+
+	if err := os.MkdirAll(gitDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Main clone: .git is a directory, so there is no linked worktree name.
+	if got := LinkedWorktreeName(dir); got != "" {
+		t.Errorf("expected empty worktree name for main clone, got %q", got)
+	}
+}
+
+func TestLinkedWorktreeNameAbsoluteGitdir(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	mainGit := filepath.Join(root, "main", ".git")
+	worktreeGitdir := filepath.Join(mainGit, "worktrees", "side")
+	worktreeDir := filepath.Join(root, "side")
+
+	if err := os.MkdirAll(worktreeGitdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.MkdirAll(worktreeDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(filepath.Join(worktreeDir, ".git"), []byte("gitdir: "+worktreeGitdir+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := LinkedWorktreeName(worktreeDir); got != "side" {
+		t.Errorf("expected side, got %q", got)
+	}
+}
+
+func TestLinkedWorktreeNameRelativeGitdir(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	mainGit := filepath.Join(root, "main", ".git")
+	worktreeGitdir := filepath.Join(mainGit, "worktrees", "rel-side")
+	worktreeDir := filepath.Join(root, "rel-side")
+
+	if err := os.MkdirAll(worktreeGitdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.MkdirAll(worktreeDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	relGitdir, err := filepath.Rel(worktreeDir, worktreeGitdir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(filepath.Join(worktreeDir, ".git"), []byte("gitdir: "+relGitdir+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := LinkedWorktreeName(worktreeDir); got != "rel-side" {
+		t.Errorf("expected rel-side, got %q", got)
+	}
+}
+
+func TestLinkedWorktreeNameUsesCwdNotGitdirBasename(t *testing.T) {
+	t.Parallel()
+
+	// Two worktrees can share an on-disk directory basename ("side") while git
+	// disambiguates their metadata dirs (worktrees/side, worktrees/side1). The
+	// displayed name must follow the on-disk directory the user sees, not the
+	// disambiguated metadata basename.
+	root := t.TempDir()
+	worktreeGitdir := filepath.Join(root, "main", ".git", "worktrees", "side1")
+	worktreeDir := filepath.Join(root, "other", "side")
+
+	if err := os.MkdirAll(worktreeGitdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.MkdirAll(worktreeDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(filepath.Join(worktreeDir, ".git"), []byte("gitdir: "+worktreeGitdir+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := LinkedWorktreeName(worktreeDir); got != "side" {
+		t.Errorf("expected side (on-disk dir name), got %q", got)
+	}
+}
+
+func TestLinkedWorktreeNameMalformedGitFile(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(dir, ".git"), []byte("not a gitdir pointer\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := LinkedWorktreeName(dir); got != "" {
+		t.Errorf("expected empty worktree name for malformed .git file, got %q", got)
+	}
+}
+
+func TestLinkedWorktreeNameGitdirNotUnderWorktrees(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	// A .git file pointing somewhere that is not a ".../worktrees/<name>"
+	// layout must not be mistaken for a linked worktree.
+	otherGitdir := filepath.Join(root, "somewhere", "custom")
+	worktreeDir := filepath.Join(root, "wt")
+
+	if err := os.MkdirAll(otherGitdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.MkdirAll(worktreeDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(filepath.Join(worktreeDir, ".git"), []byte("gitdir: "+otherGitdir+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := LinkedWorktreeName(worktreeDir); got != "" {
+		t.Errorf("expected empty worktree name when gitdir is not under worktrees/, got %q", got)
+	}
+}


### PR DESCRIPTION
## What

Split the repo segment's single `@ <name>` slot into two distinct markers: `🌳` for the linked-worktree directory name and `🌿` for the current branch.

Before, the segment showed `🐙 owner/repo @ <name>`, where `<name>` was the branch — or the worktree name only as a fallback when HEAD was unreadable. The two facts (which worktree, which branch) could not be seen at the same time.

Now both render independently, e.g. inside a linked worktree:

`🐙 lexfrei/claudeline 🌳 modular-yawning-sutton 🌿 feat/statusline-worktree-branch`

## Behavior

- `🌳 worktree` appears only inside a linked worktree. In the main clone it is omitted (the name would just repeat the repo directory).
- `🌿 branch` is read directly from `cwd/.git/HEAD`, no `git` binary required.
- The same name is never printed under both markers: the branch marker is dropped when it equals the worktree directory name (the common `git worktree add ../feat-x feat-x` pattern), and the stdin `git_worktree` fallback is suppressed when a `🌳` marker is already shown.
- The worktree name comes from the on-disk directory (`cwd` basename), not the git metadata directory, so colliding basenames (`worktrees/side` vs `worktrees/side1`) still display the name the user actually sees.

## Notes

- `LinkedWorktreeName` reads the `.git` pointer file directly, reusing the existing `.git` resolution that `CurrentBranch` already relies on (extracted into `resolveGitDir`).
- Documentation updated: example output, segment table, and per-marker descriptions.
