### PR TITLE
docs: add mise installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,12 @@ Disable with `--no-offpeak` or `offpeak = false` in config.
 brew install lexfrei/tap/claudeline
 ```
 
+### mise
+
+```bash
+mise use -g aqua:lexfrei/claudeline
+```
+
 ### From source
 
 ```bash


### PR DESCRIPTION
claudeline landed in the [aqua registry](https://github.com/aquaproj/aqua-registry/pull/55083), so it can now be installed with [mise](https://mise.jdx.dev) via the aqua backend.

This adds a `### mise` section to Installation:

```bash
mise use -g aqua:lexfrei/claudeline
```