### PR TITLE
feat(statusline): show the quota of the selected model

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Real-time statusline for [Claude Code](https://docs.anthropic.com/en/docs/claude
 | 🔄 Compactions | Number of context compactions in current session |
 | 🟢/🟡/🟠/🔴 7d | 7-day rolling quota utilization with time until reset |
 | 🟢/🟡/🟠/🔴 5h | 5-hour rolling quota utilization with time until reset |
+| 🟢/🟡/🟠/🔴 7d-&lt;model&gt; | 7-day quota of the model in use, labelled after the bucket the server reports, e.g. `7d-fable` (requires [`--mac-insecure`](#advanced---mac-insecure-mode)) |
 
 ### Model indicators
 
@@ -160,12 +161,13 @@ status = true
 context = true
 compactions = true
 quota = true
+per_model_quota = "auto" # only takes effect with mac_insecure
 
 [cache]
 status_ttl = "15s"
 ```
 
-Set any segment to `false` to hide it (`cost` accepts `"auto"`, `"true"`, `"false"`; `theme` accepts `"emoji"`, `"text"`).
+Set any segment to `false` to hide it (`cost` and `per_model_quota` accept `"auto"`, `"true"`, `"false"`; `theme` accepts `"emoji"`, `"text"`).
 
 Run `claudeline validate --config ~/.claudelinerc.toml` to check your config for typos and invalid values.
 
@@ -178,35 +180,53 @@ claudeline --cost false --no-status
 claudeline --config /path/to/config.toml
 ```
 
-Available flags: `--theme`, `--no-model`, `--no-effort`, `--no-thinking`, `--no-fast-mode`, `--no-repo`, `--no-worktree`, `--cost`, `--no-status`, `--no-context`, `--no-compactions`, `--no-quota`, `--mac-insecure`, `--per-model-quota`, `--no-credits`. The last two only take effect with `--mac-insecure`.
+Available flags: `--theme`, `--no-model`, `--no-effort`, `--no-thinking`, `--no-fast-mode`, `--no-repo`, `--no-worktree`, `--cost`, `--no-status`, `--no-context`, `--no-compactions`, `--no-quota`, `--mac-insecure`, `--per-model-quota=auto|true|false`, `--no-credits`. The last two only take effect with `--mac-insecure`.
+
+`--per-model-quota` is the one flag whose value must be attached with `=` (a bare `--per-model-quota` keeps its old meaning, "every window", which rules out the space form). See [Per-model quota modes](#per-model-quota-modes).
 
 ## Advanced: `--mac-insecure` mode
 
 For additional data not available in stdin, claudeline can access the Anthropic usage API directly via macOS Keychain. This gives you:
 
-- Per-model 7-day quotas (Opus, Sonnet, Cowork, OAuth apps)
+- Per-model 7-day quotas, including the buckets the API reports per model (Opus, Sonnet, Fable, …)
 - Extra credit usage (💳 segment)
+
+Stdin carries only the account-wide 5-hour and 7-day windows, so per-model quotas are available in this mode alone.
 
 **Security note:** this mode reads your OAuth token from macOS Keychain. Only enable it if you understand the implications.
 
 ```bash
-claudeline --mac-insecure --per-model-quota
+claudeline --mac-insecure
 ```
 
 ```toml
 mac_insecure = true
 
 [segments]
-per_model_quota = true
+per_model_quota = "auto"
 credits = true
 
 [cache]
 usage_ttl = "10m"
 ```
 
-Additional flags with `--mac-insecure`: `--per-model-quota`, `--no-credits`.
-
 **Known limitations of `--mac-insecure`:** the Anthropic usage API has a very low rate limit (~5 requests per window). Responses are cached for 10 minutes by default (`usage_ttl`). macOS only.
+
+### Per-model quota modes
+
+`per_model_quota` selects which per-model windows are shown:
+
+| Mode | Behavior |
+| --- | --- |
+| `auto` (default) | Only the window of the model in use — selecting Fable shows `7d-fable`, selecting Opus shows `7d-opus`. The label follows the bucket the server reports, so a finer bucket renders under its own name (`7d-sonnet-4-5`) |
+| `true` | Every window the API reports |
+| `false` | No per-model windows |
+
+**The default changed:** per-model quotas used to be off unless explicitly enabled. They now default to `auto`, so a `--mac-insecure` statusline gains a `7d-<model>` segment whenever the API reports a quota for the model in use. Set `per_model_quota = false` to restore the previous behavior.
+
+On the command line the value must be attached with `=`: `--per-model-quota=auto`, `--per-model-quota=true`, `--per-model-quota=false`. A bare `--per-model-quota` still means "every window", as it always did.
+
+Model buckets are named by the server, so a quota for a newly released model appears without a claudeline update.
 
 ## License
 

--- a/cmd/claudeline/main.go
+++ b/cmd/claudeline/main.go
@@ -26,13 +26,6 @@ var (
 	commit  = "none"
 )
 
-const (
-	labelSevenDayOpus      = "7d-opus"
-	labelSevenDaySonnet    = "7d-sonnet"
-	labelSevenDayCowork    = "7d-cowork"
-	labelSevenDayOAuthApps = "7d-oauth"
-)
-
 type stdinRateWindow struct {
 	UsedPercentage float64 `json:"used_percentage"` //nolint:tagliatelle // External API format
 	ResetsAt       float64 `json:"resets_at"`       //nolint:tagliatelle // External API format
@@ -52,6 +45,7 @@ type stdinPRInfo struct {
 
 type stdinData struct {
 	Model struct {
+		ID          string `json:"id"`
 		DisplayName string `json:"display_name"` //nolint:tagliatelle // External API format
 	} `json:"model"`
 	Effort struct {
@@ -135,7 +129,15 @@ func newRootCmd() *cobra.Command {
 	flags.Bool("no-compactions", false, "disable compactions segment")
 	flags.Bool("no-quota", false, "disable quota segment")
 	flags.Bool("mac-insecure", false, "use macOS Keychain + Anthropic API for per-model quotas and credits")
-	flags.Bool("per-model-quota", false, "enable per-model quota segments (requires --mac-insecure)")
+	// The value must be attached with "=": a bare --per-model-quota keeps its
+	// original meaning (show every window), which requires NoOptDefVal, and a
+	// flag carrying NoOptDefVal never consumes the next argument — so the space
+	// form would leave the value behind as a positional arg and exit non-zero,
+	// blanking the statusline. Spell the "=" form everywhere it is documented.
+	flags.String("per-model-quota", "",
+		"per-model quota segments, requires --mac-insecure: --per-model-quota=auto (selected model, default), =true (all), =false (none)")
+	flags.Lookup("per-model-quota").NoOptDefVal = config.PerModelAll
+
 	flags.Bool("no-credits", false, "disable credits segment (only with --mac-insecure)")
 	flags.String("theme", "", "icon theme: emoji (default) or text")
 
@@ -231,10 +233,19 @@ func applyIdentityFlags(cmd *cobra.Command, cfg *config.Config) {
 }
 
 func applyDisplayFlags(cmd *cobra.Command, cfg *config.Config) {
-	if flagSet(cmd, "cost") {
-		if val, _ := cmd.PersistentFlags().GetString("cost"); val != "" {
-			cfg.Segments.Cost = val
+	// The flag takes the same spellings as the config key, and an unknown value
+	// warns instead of being swallowed — a mode that silently reads as "auto"
+	// looks identical to a typo that did nothing. An empty --cost= carries no
+	// choice, so it leaves the config value alone.
+	if raw, _ := cmd.PersistentFlags().GetString("cost"); flagSet(cmd, "cost") && raw != "" {
+		mode := config.NormalizeCostMode(raw)
+		if mode == "" {
+			fmt.Fprintf(os.Stderr, "claudeline: invalid cost mode %q, using auto\n", raw)
+
+			mode = config.CostAuto
 		}
+
+		cfg.Segments.Cost = mode
 	}
 
 	if flagSet(cmd, "theme") {
@@ -265,8 +276,17 @@ func applyUsageFlags(cmd *cobra.Command, cfg *config.Config) {
 		cfg.MacInsecure = true
 	}
 
-	if flagSet(cmd, "per-model-quota") {
-		cfg.Segments.PerModelQuota = true
+	// As with --cost, an empty --per-model-quota= carries no choice and leaves the
+	// config value alone.
+	if raw, _ := cmd.PersistentFlags().GetString("per-model-quota"); flagSet(cmd, "per-model-quota") && raw != "" {
+		mode := config.NormalizePerModelQuota(raw)
+		if mode == "" {
+			fmt.Fprintf(os.Stderr, "claudeline: invalid per-model quota mode %q, using auto\n", raw)
+
+			mode = config.PerModelAuto
+		}
+
+		cfg.Segments.PerModelQuota = mode
 	}
 
 	if flagSet(cmd, "no-credits") {
@@ -573,60 +593,127 @@ func buildQuotaFromStdin(data *stdinData) *fmtutil.Data {
 	}
 }
 
-func appendQuotaWindows(segments []string, data *fmtutil.Data, perModel bool) []string {
+// modelQuotaSelector picks the per-model quota windows to display, following the
+// per_model_quota mode and the model currently selected in the session.
+type modelQuotaSelector struct {
+	mode        string
+	modelID     string
+	displayName string
+}
+
+// newModelQuotaSelector normalizes the mode rather than trusting its writers to
+// have done it: an unrecognized value would otherwise fall through to auto, which
+// is indistinguishable from having asked for auto.
+func newModelQuotaSelector(data *stdinData, cfg *config.Config) modelQuotaSelector {
+	mode := config.NormalizePerModelQuota(cfg.Segments.PerModelQuota)
+	if mode == "" {
+		mode = config.PerModelAuto
+	}
+
+	return modelQuotaSelector{
+		mode:        mode,
+		modelID:     data.Model.ID,
+		displayName: data.Model.DisplayName,
+	}
+}
+
+// windows returns nothing when per-model quotas are off, every reported window
+// when they are all requested, and otherwise (auto) only the window belonging to
+// the model in use — so switching to Fable surfaces the Fable bucket by itself.
+// A model reported by more than one bucket collapses to the bucket closest to
+// its limit, so the constraint that will bite first is never the hidden one.
+func (s modelQuotaSelector) windows(data *fmtutil.Data) []fmtutil.ScopedWindow {
+	if data == nil || s.mode == config.PerModelOff {
+		return nil
+	}
+
+	if s.mode == config.PerModelAll {
+		return data.PerModelWindows()
+	}
+
+	// Match against the uncollapsed candidates: two buckets can share a label
+	// while naming different models, and collapsing first could let the bucket of
+	// another model win the label and hide the one that applies here.
+	candidates := data.PerModelCandidates()
+
+	matched := make([]fmtutil.ScopedWindow, 0, len(candidates))
+
+	for _, win := range candidates {
+		if fmtutil.MatchesScopedModel(s.modelID, s.displayName, win) {
+			matched = append(matched, win)
+		}
+	}
+
+	return fmtutil.MostBinding(matched)
+}
+
+// appendWindowSegments renders the account-wide windows followed by the per-model
+// ones the caller selected, through the given formatter. The fresh and the stale
+// paths differ only in that formatter, so the window list is assembled once.
+func appendWindowSegments(
+	segments []string,
+	data *fmtutil.Data,
+	perModel []fmtutil.ScopedWindow,
+	format func(*fmtutil.QuotaWindow, string) string,
+) []string {
 	type labeledWindow struct {
 		win   *fmtutil.QuotaWindow
 		label string
 	}
 
-	windows := []labeledWindow{
-		{data.SevenDay, "7d"},
-		{data.FiveHour, "5h"},
-	}
+	windows := make([]labeledWindow, 0, 2+len(perModel)) //nolint:mnd // the two account-wide windows below
+	windows = append(windows,
+		labeledWindow{data.SevenDay, "7d"},
+		labeledWindow{data.FiveHour, "5h"},
+	)
 
-	if perModel {
-		windows = append(windows,
-			labeledWindow{data.SevenDayOpus, labelSevenDayOpus},
-			labeledWindow{data.SevenDaySonnet, labelSevenDaySonnet},
-			labeledWindow{data.SevenDayCowork, labelSevenDayCowork},
-			labeledWindow{data.SevenDayOAuthApps, labelSevenDayOAuthApps},
-		)
+	for _, scoped := range perModel {
+		windows = append(windows, labeledWindow{scoped.Window, fmtutil.ScopedLabel(scoped.Name)})
 	}
 
 	for _, w := range windows {
 		if w.win != nil {
-			segments = append(segments, fmtutil.FormatQuotaWindow(w.win, w.label))
+			segments = append(segments, format(w.win, w.label))
 		}
 	}
 
 	return segments
 }
 
+func appendQuotaWindows(segments []string, data *fmtutil.Data, perModel []fmtutil.ScopedWindow) []string {
+	return appendWindowSegments(segments, data, perModel, fmtutil.FormatQuotaWindow)
+}
+
 func appendUsageSegments(segments []string, data *stdinData, cfg *config.Config) []string {
 	if cfg.MacInsecure {
-		return appendInsecureUsageSegments(segments, cfg)
+		return appendInsecureUsageSegments(segments, data, cfg)
 	}
 
 	return appendStdinUsageSegments(segments, data, cfg)
 }
 
 // appendStdinUsageSegments builds quota segments from stdin rate_limits (default, secure path).
+// Per-model windows are unavailable here: stdin carries only the account-wide
+// five_hour and seven_day windows.
 func appendStdinUsageSegments(segments []string, data *stdinData, cfg *config.Config) []string {
 	quotaData := buildQuotaFromStdin(data)
 
 	if cfg.Segments.Quota {
-		segments = appendQuotaWindows(segments, quotaData, false)
+		segments = appendQuotaWindows(segments, quotaData, nil)
 	}
 
 	return segments
 }
 
 // appendInsecureUsageSegments builds quota segments from Anthropic API via macOS Keychain (--mac-insecure).
-func appendInsecureUsageSegments(segments []string, cfg *config.Config) []string {
+// Per-model quotas live only here: the API reports them, stdin does not.
+func appendInsecureUsageSegments(segments []string, data *stdinData, cfg *config.Config) []string {
+	selector := newModelQuotaSelector(data, cfg)
+
 	usageData, err := usage.Fetch()
 	if err != nil {
 		if cfg.Segments.Quota {
-			segments = appendStaleQuotaSegments(segments, cfg.Segments.PerModelQuota)
+			segments = appendStaleQuotaSegments(segments, selector)
 		}
 
 		return segments
@@ -636,13 +723,13 @@ func appendInsecureUsageSegments(segments []string, cfg *config.Config) []string
 	case "":
 		// no error, continue
 	case "rate_limit_error":
-		return appendRateLimitSegments(segments, cfg)
+		return appendRateLimitSegments(segments, cfg, selector)
 	default:
 		return append(segments, fmtutil.Part("/login needed", "⚠️"))
 	}
 
 	if cfg.Segments.Quota {
-		segments = appendQuotaWindows(segments, usageData, cfg.Segments.PerModelQuota)
+		segments = appendQuotaWindows(segments, usageData, selector.windows(usageData))
 	}
 
 	if cfg.Segments.Credits && usageData.Extra != nil && usageData.Extra.UsedCredits > 0 {
@@ -653,46 +740,32 @@ func appendInsecureUsageSegments(segments []string, cfg *config.Config) []string
 	return segments
 }
 
-func appendStaleQuotaSegments(segments []string, perModel bool) []string {
+func appendStaleQuotaSegments(segments []string, selector modelQuotaSelector) []string {
 	lastGood := usage.FetchLastGood()
+
+	return appendStaleQuotaWindows(segments, lastGood, selector.windows(lastGood))
+}
+
+// appendStaleQuotaWindows renders last-good data the caller already fetched and
+// already ran through the selector. Both are worth doing once: reading last-good
+// is a file read plus a parse that rewrites the cache, and the rate-limit path
+// needs the selected windows anyway to name the exhausted one.
+func appendStaleQuotaWindows(segments []string, lastGood *fmtutil.Data, perModel []fmtutil.ScopedWindow) []string {
 	if lastGood == nil {
 		return append(segments, fmtutil.Part("7d: ?% (?d)", "⏳"), fmtutil.Part("5h: ?% (?h)", "⏳"))
 	}
 
-	type labeledWindow struct {
-		win   *fmtutil.QuotaWindow
-		label string
-	}
-
-	windows := []labeledWindow{
-		{lastGood.SevenDay, "7d"},
-		{lastGood.FiveHour, "5h"},
-	}
-
-	if perModel {
-		windows = append(windows,
-			labeledWindow{lastGood.SevenDayOpus, labelSevenDayOpus},
-			labeledWindow{lastGood.SevenDaySonnet, labelSevenDaySonnet},
-			labeledWindow{lastGood.SevenDayCowork, labelSevenDayCowork},
-			labeledWindow{lastGood.SevenDayOAuthApps, labelSevenDayOAuthApps},
-		)
-	}
-
-	for _, w := range windows {
-		if w.win != nil {
-			segments = append(segments, fmtutil.FormatStaleQuotaWindow(w.win, w.label))
-		}
-	}
-
-	return segments
+	return appendWindowSegments(segments, lastGood, perModel, fmtutil.FormatStaleQuotaWindow)
 }
 
-func appendRateLimitSegments(segments []string, cfg *config.Config) []string {
+func appendRateLimitSegments(segments []string, cfg *config.Config, selector modelQuotaSelector) []string {
 	lastGood := usage.FetchLastGood()
-	segments = append(segments, fmtutil.FormatRateLimitSegment(fmtutil.FindExhaustedWindow(lastGood, cfg.Segments.PerModelQuota)))
+	perModel := selector.windows(lastGood)
+
+	segments = append(segments, fmtutil.FormatRateLimitSegment(fmtutil.FindExhaustedWindow(lastGood, perModel)))
 
 	if cfg.Segments.Quota {
-		segments = appendStaleQuotaSegments(segments, cfg.Segments.PerModelQuota)
+		segments = appendStaleQuotaWindows(segments, lastGood, perModel)
 	}
 
 	return segments

--- a/cmd/claudeline/main_test.go
+++ b/cmd/claudeline/main_test.go
@@ -1110,7 +1110,7 @@ func TestAppendUsageSegmentsPerModel(t *testing.T) {
 	}
 
 	cfg := insecureCfg()
-	cfg.Segments.PerModelQuota = true
+	cfg.Segments.PerModelQuota = config.PerModelAll
 
 	segments := appendUsageSegments(nil, &stdinData{}, cfg)
 	joined := strings.Join(segments, " | ")
@@ -1247,7 +1247,7 @@ func TestNewRootCmdWithFlags(t *testing.T) {
 	usage.HTTPGetFn = failHTTP
 
 	cmd := newRootCmd()
-	cmd.SetArgs([]string{flagNoModel, flagNoWorktree, "--cost", "false", "--config", "/nonexistent/config.toml"})
+	cmd.SetArgs([]string{flagNoModel, flagNoWorktree, "--cost", "false", flagConfig, "/nonexistent/config.toml"})
 	cmd.SetIn(strings.NewReader(`{"workspace":{"git_worktree":"feat-api"}}`))
 
 	captured := captureStdout(t, func() {
@@ -1325,7 +1325,7 @@ usage_ttl = "30s"
 	}
 
 	cmd := newRootCmd()
-	cmd.SetArgs([]string{"--config", configPath})
+	cmd.SetArgs([]string{flagConfig, configPath})
 	cmd.SetIn(strings.NewReader(`{}`))
 
 	err := cmd.Execute()
@@ -1340,9 +1340,9 @@ usage_ttl = "30s"
 
 func TestApplyFlagOverrides(t *testing.T) {
 	cmd := newRootCmd()
-	cmd.SetArgs([]string{flagNoModel, flagNoWorktree, "--no-quota", "--no-credits", "--per-model-quota", "--mac-insecure"})
+	cmd.SetArgs([]string{flagNoModel, flagNoWorktree, "--no-quota", "--no-credits", flagPerModelQuota, "--mac-insecure"})
 
-	parseErr := cmd.ParseFlags([]string{flagNoModel, flagNoWorktree, "--no-quota", "--no-credits", "--per-model-quota", "--mac-insecure"})
+	parseErr := cmd.ParseFlags([]string{flagNoModel, flagNoWorktree, "--no-quota", "--no-credits", flagPerModelQuota, "--mac-insecure"})
 	if parseErr != nil {
 		t.Fatal(parseErr)
 	}
@@ -1366,8 +1366,8 @@ func TestApplyFlagOverrides(t *testing.T) {
 		t.Error("expected credits disabled by flag")
 	}
 
-	if !cfg.Segments.PerModelQuota {
-		t.Error("expected per-model quota enabled by flag")
+	if cfg.Segments.PerModelQuota != config.PerModelAll {
+		t.Error("expected per-model quota set to all by flag")
 	}
 
 	if cfg.Segments.Cost == config.CostOff {

--- a/cmd/claudeline/permodel_test.go
+++ b/cmd/claudeline/permodel_test.go
@@ -1,0 +1,637 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/lexfrei/claudeline/internal/config"
+	"github.com/lexfrei/claudeline/internal/httpclient"
+	"github.com/lexfrei/claudeline/internal/keychain"
+	"github.com/lexfrei/claudeline/internal/usage"
+)
+
+const (
+	flagConfig        = "--config"
+	flagPerModelQuota = "--per-model-quota"
+)
+
+// stubScopedUsageAPI serves a usage response holding a top-level Opus window and
+// a Fable window delivered the way the API actually delivers per-model quotas:
+// as a model-scoped entry of limits[].
+func stubScopedUsageAPI(t *testing.T) {
+	t.Helper()
+
+	resetsAt := time.Now().Add(72 * time.Hour).UTC().Format(time.RFC3339)
+
+	keychain.GetFn = func() (string, error) { return testToken, nil }
+	usage.HTTPGetFn = func(_ string, _ map[string]string, _ time.Duration) (*httpclient.Response, error) {
+		return &httpclient.Response{
+			StatusCode: http.StatusOK,
+			Body: []byte(`{
+				"seven_day": {"utilization": 45, "resets_at": "` + resetsAt + `"},
+				"seven_day_opus": {"utilization": 12, "resets_at": "` + resetsAt + `"},
+				"limits": [
+					{"kind": "weekly_scoped", "group": "weekly", "percent": 90,
+					 "resets_at": "` + resetsAt + `",
+					 "scope": {"model": {"id": null, "display_name": "Fable"}}}
+				]
+			}`),
+		}, nil
+	}
+}
+
+func modelStdin(id, displayName string) *stdinData {
+	data := &stdinData{}
+	data.Model.ID = id
+	data.Model.DisplayName = displayName
+
+	return data
+}
+
+func TestPerModelQuotaAutoShowsSelectedModelOnly(t *testing.T) {
+	cleanup := setupTestEnv(t)
+	defer cleanup()
+
+	stubScopedUsageAPI(t)
+
+	cfg := insecureCfg()
+	cfg.Segments.PerModelQuota = config.PerModelAuto
+
+	joined := strings.Join(appendUsageSegments(nil, modelStdin("claude-fable-5", "Fable 5"), cfg), " | ")
+
+	if !strings.Contains(joined, "7d-fable: 90%") {
+		t.Errorf("expected the Fable window while Fable is selected, got %q", joined)
+	}
+
+	if strings.Contains(joined, "7d-opus") {
+		t.Errorf("expected no Opus window while Fable is selected, got %q", joined)
+	}
+
+	if !strings.Contains(joined, "7d: 45%") {
+		t.Errorf("expected the account-wide window, got %q", joined)
+	}
+}
+
+func TestPerModelQuotaAutoFollowsTheModel(t *testing.T) {
+	cleanup := setupTestEnv(t)
+	defer cleanup()
+
+	stubScopedUsageAPI(t)
+
+	cfg := insecureCfg()
+	cfg.Segments.PerModelQuota = config.PerModelAuto
+
+	joined := strings.Join(appendUsageSegments(nil, modelStdin("claude-opus-4-8", "Opus 4.8"), cfg), " | ")
+
+	if !strings.Contains(joined, "7d-opus: 12%") {
+		t.Errorf("expected the Opus window while Opus is selected, got %q", joined)
+	}
+
+	if strings.Contains(joined, "7d-fable") {
+		t.Errorf("expected no Fable window while Opus is selected, got %q", joined)
+	}
+}
+
+func TestPerModelQuotaAllShowsEveryWindow(t *testing.T) {
+	cleanup := setupTestEnv(t)
+	defer cleanup()
+
+	stubScopedUsageAPI(t)
+
+	cfg := insecureCfg()
+	cfg.Segments.PerModelQuota = config.PerModelAll
+
+	joined := strings.Join(appendUsageSegments(nil, modelStdin("claude-opus-4-8", "Opus 4.8"), cfg), " | ")
+
+	for _, want := range []string{"7d-opus: 12%", "7d-fable: 90%"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("expected %q in all-windows mode, got %q", want, joined)
+		}
+	}
+}
+
+func TestPerModelQuotaOffHidesEveryWindow(t *testing.T) {
+	cleanup := setupTestEnv(t)
+	defer cleanup()
+
+	stubScopedUsageAPI(t)
+
+	cfg := insecureCfg()
+	cfg.Segments.PerModelQuota = config.PerModelOff
+
+	joined := strings.Join(appendUsageSegments(nil, modelStdin("claude-fable-5", "Fable 5"), cfg), " | ")
+
+	for _, unwanted := range []string{"7d-fable", "7d-opus"} {
+		if strings.Contains(joined, unwanted) {
+			t.Errorf("expected no %s window when per-model quotas are off, got %q", unwanted, joined)
+		}
+	}
+
+	if !strings.Contains(joined, "7d: 45%") {
+		t.Errorf("expected the account-wide window to survive, got %q", joined)
+	}
+}
+
+// A model can be reported by two buckets at once — the coarse family window
+// (seven_day_sonnet) and a finer server-named one ("Sonnet 4.5"). Both match the
+// selected model, so auto mode must pick exactly one, or the statusline renders
+// the same model twice. It keeps whichever is closer to its limit: usually the
+// narrower bucket, but never at the price of hiding the quota about to run out.
+func TestPerModelQuotaAutoPicksTheBindingBucket(t *testing.T) {
+	tests := []struct {
+		name        string
+		familyPct   int
+		scopedPct   int
+		wantSegment string
+		wantDropped string
+	}{
+		{
+			name:        "narrower bucket is the one filling up",
+			familyPct:   30,
+			scopedPct:   60,
+			wantSegment: "7d-sonnet-4-5: 60%",
+			wantDropped: "7d-sonnet: 30%",
+		},
+		{
+			name:        "family bucket is the one about to run out",
+			familyPct:   95,
+			scopedPct:   30,
+			wantSegment: "7d-sonnet: 95%",
+			wantDropped: "7d-sonnet-4-5: 30%",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cleanup := setupTestEnv(t)
+			defer cleanup()
+
+			resetsAt := time.Now().Add(72 * time.Hour).UTC().Format(time.RFC3339)
+
+			keychain.GetFn = func() (string, error) { return testToken, nil }
+			usage.HTTPGetFn = func(_ string, _ map[string]string, _ time.Duration) (*httpclient.Response, error) {
+				return &httpclient.Response{
+					StatusCode: http.StatusOK,
+					Body: fmt.Appendf(nil, `{
+						"seven_day_sonnet": {"utilization": %d, "resets_at": %q},
+						"limits": [
+							{"kind": "weekly_scoped", "group": "weekly", "percent": %d,
+							 "resets_at": %q,
+							 "scope": {"model": {"display_name": "Sonnet 4.5"}}}
+						]
+					}`, tt.familyPct, resetsAt, tt.scopedPct, resetsAt),
+				}, nil
+			}
+
+			cfg := insecureCfg()
+			cfg.Segments.PerModelQuota = config.PerModelAuto
+
+			joined := strings.Join(appendUsageSegments(nil, modelStdin("claude-sonnet-4-5", "Sonnet 4.5"), cfg), " | ")
+
+			if !strings.Contains(joined, tt.wantSegment) {
+				t.Errorf("expected %q, got %q", tt.wantSegment, joined)
+			}
+
+			if strings.Contains(joined, tt.wantDropped) {
+				t.Errorf("expected %q to be dropped as a duplicate, got %q", tt.wantDropped, joined)
+			}
+		})
+	}
+}
+
+// Several versions of a family run at once, so the server reports a bucket per
+// version. The bucket of the version the session is NOT running must never be
+// picked, however close to its limit it sits — a red segment for someone else's
+// quota is worse than no segment at all.
+func TestPerModelQuotaAutoIgnoresOtherVersionsOfTheFamily(t *testing.T) {
+	cleanup := setupTestEnv(t)
+	defer cleanup()
+
+	resetsAt := time.Now().Add(72 * time.Hour).UTC().Format(time.RFC3339)
+
+	keychain.GetFn = func() (string, error) { return testToken, nil }
+	usage.HTTPGetFn = func(_ string, _ map[string]string, _ time.Duration) (*httpclient.Response, error) {
+		return &httpclient.Response{
+			StatusCode: http.StatusOK,
+			Body: fmt.Appendf(nil, `{
+				"seven_day": {"utilization": 40, "resets_at": %q},
+				"limits": [
+					{"kind": "weekly_scoped", "group": "weekly", "percent": 95, "resets_at": %q,
+					 "scope": {"model": {"display_name": "Claude Sonnet 4"}}},
+					{"kind": "weekly_scoped", "group": "weekly", "percent": 12, "resets_at": %q,
+					 "scope": {"model": {"display_name": "Claude Sonnet 4.5"}}}
+				]
+			}`, resetsAt, resetsAt, resetsAt),
+		}, nil
+	}
+
+	cfg := insecureCfg()
+	cfg.Segments.PerModelQuota = config.PerModelAuto
+
+	joined := strings.Join(appendUsageSegments(nil, modelStdin("claude-sonnet-4-5-20250929", "Sonnet 4.5"), cfg), " | ")
+
+	if !strings.Contains(joined, "7d-claude-sonnet-4-5: 12%") {
+		t.Errorf("expected the running model's own bucket, got %q", joined)
+	}
+
+	if strings.Contains(joined, "7d-claude-sonnet-4: 95%") {
+		t.Errorf("expected the Sonnet 4 bucket to be ignored on a Sonnet 4.5 session, got %q", joined)
+	}
+}
+
+// When the server scopes a bucket to a model id, that id decides the match — the
+// name is only a fallback. Pinned so a bucket whose name would not match still
+// renders when its id does.
+func TestPerModelQuotaAutoMatchesOnServerID(t *testing.T) {
+	cleanup := setupTestEnv(t)
+	defer cleanup()
+
+	resetsAt := time.Now().Add(72 * time.Hour).UTC().Format(time.RFC3339)
+
+	keychain.GetFn = func() (string, error) { return testToken, nil }
+	usage.HTTPGetFn = func(_ string, _ map[string]string, _ time.Duration) (*httpclient.Response, error) {
+		return &httpclient.Response{
+			StatusCode: http.StatusOK,
+			Body: fmt.Appendf(nil, `{
+				"limits": [
+					{"kind": "weekly_scoped", "group": "weekly", "percent": 42, "resets_at": %q,
+					 "scope": {"model": {"id": "claude-fable-5", "display_name": "Storyteller"}}}
+				]
+			}`, resetsAt),
+		}, nil
+	}
+
+	cfg := insecureCfg()
+	cfg.Segments.PerModelQuota = config.PerModelAuto
+
+	joined := strings.Join(appendUsageSegments(nil, modelStdin("claude-fable-5", "Fable 5"), cfg), " | ")
+
+	if !strings.Contains(joined, "7d-storyteller: 42%") {
+		t.Errorf("expected the bucket matched by server id, got %q", joined)
+	}
+}
+
+// Two buckets can share a label while naming different models: the family window
+// (seven_day_opus, covering every Opus) and a limits[] entry scoped to one
+// version. Auto mode must pick among the buckets that match the running model —
+// collapsing the label first would let the non-matching version win the collision
+// and take the applicable family window down with it.
+func TestPerModelQuotaAutoKeepsTheApplicableWindowOnLabelCollision(t *testing.T) {
+	cleanup := setupTestEnv(t)
+	defer cleanup()
+
+	resetsAt := time.Now().Add(72 * time.Hour).UTC().Format(time.RFC3339)
+
+	keychain.GetFn = func() (string, error) { return testToken, nil }
+	usage.HTTPGetFn = func(_ string, _ map[string]string, _ time.Duration) (*httpclient.Response, error) {
+		return &httpclient.Response{
+			StatusCode: http.StatusOK,
+			Body: fmt.Appendf(nil, `{
+				"seven_day_opus": {"utilization": 20, "resets_at": %q},
+				"limits": [
+					{"kind": "weekly_scoped", "group": "weekly", "percent": 96, "resets_at": %q,
+					 "scope": {"model": {"id": "claude-opus-4-5", "display_name": "Opus"}}}
+				]
+			}`, resetsAt, resetsAt),
+		}, nil
+	}
+
+	cfg := insecureCfg()
+	cfg.Segments.PerModelQuota = config.PerModelAuto
+
+	joined := strings.Join(appendUsageSegments(nil, modelStdin("claude-opus-4-8", "Opus 4.8"), cfg), " | ")
+
+	if !strings.Contains(joined, "7d-opus: 20%") {
+		t.Errorf("expected the family window that applies to this Opus, got %q", joined)
+	}
+
+	if strings.Contains(joined, "96%") {
+		t.Errorf("expected the quota of another Opus version to stay hidden, got %q", joined)
+	}
+}
+
+// stdin carries the dated model id while the server scopes its bucket to the
+// undated one. They name one model, so the segment must still render — comparing
+// the ids for equality would silently drop it.
+func TestPerModelQuotaAutoMatchesDatedModelID(t *testing.T) {
+	cleanup := setupTestEnv(t)
+	defer cleanup()
+
+	resetsAt := time.Now().Add(72 * time.Hour).UTC().Format(time.RFC3339)
+
+	keychain.GetFn = func() (string, error) { return testToken, nil }
+	usage.HTTPGetFn = func(_ string, _ map[string]string, _ time.Duration) (*httpclient.Response, error) {
+		return &httpclient.Response{
+			StatusCode: http.StatusOK,
+			Body: fmt.Appendf(nil, `{
+				"limits": [
+					{"kind": "weekly_scoped", "group": "weekly", "percent": 55, "resets_at": %q,
+					 "scope": {"model": {"id": "claude-sonnet-4-5", "display_name": "Sonnet 4.5"}}}
+				]
+			}`, resetsAt),
+		}, nil
+	}
+
+	cfg := insecureCfg()
+	cfg.Segments.PerModelQuota = config.PerModelAuto
+
+	stdin := modelStdin("claude-sonnet-4-5-20250929", "Sonnet 4.5")
+
+	joined := strings.Join(appendUsageSegments(nil, stdin, cfg), " | ")
+
+	if !strings.Contains(joined, "7d-sonnet-4-5: 55%") {
+		t.Errorf("expected the dated model id to match the undated bucket id, got %q", joined)
+	}
+}
+
+// stubExhaustedFableCache primes the last-good cache with a spent Fable bucket
+// and makes the API answer 429, which is the state the rate-limit segment reads.
+func stubExhaustedFableCache(t *testing.T) {
+	t.Helper()
+
+	resetsAt := time.Now().Add(2 * time.Hour).UTC().Format(time.RFC3339)
+
+	if _, err := usage.ParseBody([]byte(`{
+		"seven_day": {"utilization": 40, "resets_at": "` + resetsAt + `"},
+		"limits": [
+			{"kind": "weekly_scoped", "group": "weekly", "percent": 100, "is_active": true,
+			 "resets_at": "` + resetsAt + `",
+			 "scope": {"model": {"display_name": "Fable"}}}
+		]
+	}`)); err != nil {
+		t.Fatalf("priming last-good cache: %v", err)
+	}
+
+	keychain.GetFn = func() (string, error) { return testToken, nil }
+	usage.HTTPGetFn = func(_ string, _ map[string]string, _ time.Duration) (*httpclient.Response, error) {
+		return &httpclient.Response{StatusCode: http.StatusTooManyRequests, Header: http.Header{}}, nil
+	}
+}
+
+// A model-scoped bucket may name the exhausted limit — the label comes from the
+// server's bucket name, not from a fixed list.
+func TestRateLimitSegmentNamesTheScopedWindow(t *testing.T) {
+	cleanup := setupTestEnv(t)
+	defer cleanup()
+
+	stubExhaustedFableCache(t)
+
+	cfg := insecureCfg()
+	cfg.Segments.PerModelQuota = config.PerModelAuto
+
+	joined := strings.Join(appendUsageSegments(nil, modelStdin("claude-fable-5", "Fable 5"), cfg), " | ")
+
+	if !strings.Contains(joined, "7d-fable limit hit") {
+		t.Errorf("expected the spent Fable bucket to name the limit, got %q", joined)
+	}
+}
+
+// The mirror image: a window auto mode hides must never name the limit, or the
+// statusline would blame a quota it is not showing.
+func TestRateLimitSegmentIgnoresHiddenWindow(t *testing.T) {
+	cleanup := setupTestEnv(t)
+	defer cleanup()
+
+	stubExhaustedFableCache(t)
+
+	cfg := insecureCfg()
+	cfg.Segments.PerModelQuota = config.PerModelAuto
+
+	joined := strings.Join(appendUsageSegments(nil, modelStdin("claude-opus-4-8", "Opus 4.8"), cfg), " | ")
+
+	if strings.Contains(joined, "7d-fable") {
+		t.Errorf("expected the hidden Fable bucket to stay unnamed while Opus is selected, got %q", joined)
+	}
+
+	if !strings.Contains(joined, "limit hit") {
+		t.Errorf("expected a rate-limit segment, got %q", joined)
+	}
+}
+
+// Every documented spelling of the flag must parse and resolve to the mode the
+// docs promise. The "=" form is the documented one: a bare --per-model-quota has
+// to keep meaning "all", which forces NoOptDefVal, which in turn makes the space
+// form leave its value behind as a positional argument and blank the statusline.
+func TestPerModelQuotaFlagSpellings(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"bare flag keeps meaning all", []string{flagPerModelQuota}, config.PerModelAll},
+		{"explicit auto", []string{flagPerModelQuota + "=auto"}, config.PerModelAuto},
+		{"explicit true", []string{flagPerModelQuota + "=true"}, config.PerModelAll},
+		{"explicit false", []string{flagPerModelQuota + "=false"}, config.PerModelOff},
+		{"capitalized bool still parses", []string{flagPerModelQuota + "=True"}, config.PerModelAll},
+		{"unset leaves the default", nil, config.PerModelAuto},
+		{"invalid value falls back to auto", []string{flagPerModelQuota + "=bogus"}, config.PerModelAuto},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := newRootCmd()
+			cmd.SetArgs(append([]string{flagConfig, ""}, tt.args...))
+			cmd.SetOut(io.Discard)
+			cmd.SetErr(io.Discard)
+			cmd.RunE = func(_ *cobra.Command, _ []string) error { return nil }
+			cmd.Run = nil
+
+			if err := cmd.Execute(); err != nil {
+				t.Fatalf("executing %v: %v", tt.args, err)
+			}
+
+			cfg := config.Defaults()
+			applyFlagOverrides(cmd, &cfg)
+
+			if cfg.Segments.PerModelQuota != tt.want {
+				t.Errorf("per-model quota = %q, want %q", cfg.Segments.PerModelQuota, tt.want)
+			}
+		})
+	}
+}
+
+// The flag and the config key feed the same normalizer, so every spelling the
+// config accepts must resolve identically on the command line — and an unknown
+// value must warn rather than pass silently as auto.
+func TestCostFlagSpellings(t *testing.T) {
+	tests := []struct {
+		value string
+		want  string
+	}{
+		{"auto", config.CostAuto},
+		{"true", config.CostOn},
+		{"on", config.CostOn},
+		{"1", config.CostOn},
+		{"True", config.CostOn},
+		{"false", config.CostOff},
+		{"off", config.CostOff},
+		{"bogus", config.CostAuto},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.value, func(t *testing.T) {
+			cmd := newRootCmd()
+			cmd.SetArgs([]string{flagConfig, "", "--cost", tt.value})
+			cmd.SetOut(io.Discard)
+			cmd.SetErr(io.Discard)
+			cmd.RunE = func(_ *cobra.Command, _ []string) error { return nil }
+			cmd.Run = nil
+
+			if err := cmd.Execute(); err != nil {
+				t.Fatalf("executing --cost %s: %v", tt.value, err)
+			}
+
+			cfg := config.Defaults()
+			applyFlagOverrides(cmd, &cfg)
+
+			if cfg.Segments.Cost != tt.want {
+				t.Errorf("--cost %s = %q, want %q", tt.value, cfg.Segments.Cost, tt.want)
+			}
+		})
+	}
+}
+
+// End to end: a subscriber (rate limits present) hides cost under auto, so
+// --cost on must be what makes the segment appear.
+func TestCostFlagOnRendersForSubscriber(t *testing.T) {
+	cleanup := setupTestEnv(t)
+	defer cleanup()
+
+	stdin := []byte(`{"model":{"id":"claude-opus-4-8","display_name":"Opus 4.8"},
+		"cost":{"total_cost_usd":1.23},
+		"rate_limits":{"seven_day":{"used_percentage":50,"resets_at":9999999999}}}`)
+
+	cfg := config.Defaults()
+	cfg.Segments.Cost = config.NormalizeCostMode("on")
+
+	if got := buildStatusline(stdin, &cfg); !strings.Contains(got, "$1.23") {
+		t.Errorf("expected the cost segment under --cost on, got %q", got)
+	}
+}
+
+// An empty value carries no choice, so it must leave the config value standing —
+// the same rule --cost follows. Checked from a config that says something other
+// than the default, or the assertion would pass for the wrong reason.
+func TestEmptyModeFlagsLeaveTheConfigAlone(t *testing.T) {
+	tests := []struct {
+		name string
+		arg  string
+		want func(config.Config) string
+	}{
+		{"per-model-quota", flagPerModelQuota + "=", func(c config.Config) string { return c.Segments.PerModelQuota }},
+		{"cost", "--cost=", func(c config.Config) string { return c.Segments.Cost }},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := newRootCmd()
+			cmd.SetArgs([]string{flagConfig, "", tt.arg})
+			cmd.SetOut(io.Discard)
+			cmd.SetErr(io.Discard)
+			cmd.RunE = func(_ *cobra.Command, _ []string) error { return nil }
+			cmd.Run = nil
+
+			if err := cmd.Execute(); err != nil {
+				t.Fatalf("executing %s: %v", tt.arg, err)
+			}
+
+			cfg := config.Defaults()
+			cfg.Segments.PerModelQuota = config.PerModelOff
+			cfg.Segments.Cost = config.CostOff
+
+			applyFlagOverrides(cmd, &cfg)
+
+			if got := tt.want(cfg); got != config.CostOff {
+				t.Errorf("%s overrode the config with %q, want the config value %q", tt.arg, got, config.CostOff)
+			}
+		})
+	}
+}
+
+// The space form cannot work: a bare --per-model-quota has to keep meaning "all",
+// which requires NoOptDefVal, and such a flag never consumes the next argument —
+// so the value lands as a positional arg and cobra.NoArgs rejects it. Pinned so
+// that nobody "fixes" the parsing by dropping NoOptDefVal, silently changing what
+// a bare flag means for everyone already passing it.
+func TestPerModelQuotaSpaceFormIsRejected(t *testing.T) {
+	cmd := newRootCmd()
+	cmd.SetArgs([]string{flagConfig, "", flagPerModelQuota, "auto"})
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	cmd.RunE = func(_ *cobra.Command, _ []string) error { return nil }
+	cmd.Run = nil
+
+	if err := cmd.Execute(); err == nil {
+		t.Error("expected the space form to be rejected, got no error")
+	}
+}
+
+// In "all" mode the statusline mirrors what the API reports, bucket for bucket:
+// a model covered by both a family window and a finer one shows up twice. Only
+// auto collapses them, because only auto claims to show "the current model".
+func TestPerModelQuotaAllKeepsOverlappingBuckets(t *testing.T) {
+	cleanup := setupTestEnv(t)
+	defer cleanup()
+
+	resetsAt := time.Now().Add(72 * time.Hour).UTC().Format(time.RFC3339)
+
+	keychain.GetFn = func() (string, error) { return testToken, nil }
+	usage.HTTPGetFn = func(_ string, _ map[string]string, _ time.Duration) (*httpclient.Response, error) {
+		return &httpclient.Response{
+			StatusCode: http.StatusOK,
+			Body: []byte(`{
+				"seven_day_sonnet": {"utilization": 30, "resets_at": "` + resetsAt + `"},
+				"limits": [
+					{"kind": "weekly_scoped", "group": "weekly", "percent": 60,
+					 "resets_at": "` + resetsAt + `",
+					 "scope": {"model": {"display_name": "Sonnet 4.5"}}}
+				]
+			}`),
+		}, nil
+	}
+
+	cfg := insecureCfg()
+	cfg.Segments.PerModelQuota = config.PerModelAll
+
+	joined := strings.Join(appendUsageSegments(nil, modelStdin("claude-sonnet-4-5", "Sonnet 4.5"), cfg), " | ")
+
+	for _, want := range []string{"7d-sonnet: 30%", "7d-sonnet-4-5: 60%"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("expected %q — all mode reports every bucket as-is, got %q", want, joined)
+		}
+	}
+}
+
+// The default (secure) path reads quotas from stdin, which carries no per-model
+// windows at all — so no model quota may appear there, whatever the mode says.
+func TestPerModelQuotaAbsentOnStdinPath(t *testing.T) {
+	cleanup := setupTestEnv(t)
+	defer cleanup()
+
+	stubScopedUsageAPI(t)
+
+	cfg := config.Defaults()
+	cfg.Segments.PerModelQuota = config.PerModelAll
+
+	data := modelStdin("claude-fable-5", "Fable 5")
+	data.RateLimits.SevenDay = &stdinRateWindow{
+		UsedPercentage: 45,
+		ResetsAt:       float64(time.Now().Add(72 * time.Hour).Unix()),
+	}
+
+	joined := strings.Join(appendUsageSegments(nil, data, &cfg), " | ")
+
+	if strings.Contains(joined, "7d-fable") {
+		t.Errorf("expected no per-model window on the stdin path, got %q", joined)
+	}
+
+	if !strings.Contains(joined, "7d: 45%") {
+		t.Errorf("expected the stdin 7d window, got %q", joined)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,6 +4,7 @@ package config
 import (
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/spf13/viper"
@@ -14,26 +15,73 @@ const (
 	defaultStatusTTL = 15 * time.Second
 )
 
-// Cost mode values.
+// Canonical values every mode option resolves to. The options below are named
+// after them so a mode can be compared without knowing which option it came from.
 const (
-	CostAuto = "auto"
-	CostOn   = "true"
-	CostOff  = "false"
+	modeAuto = "auto"
+	modeOn   = "true"
+	modeOff  = "false"
 )
 
-// NormalizeCostMode converts various user inputs to a canonical cost mode.
-// Accepts: "auto", "true"/"1"/"on", "false"/"0"/"off". Returns "" for unknown values.
-func NormalizeCostMode(raw string) string {
-	switch raw {
-	case CostAuto, "":
-		return CostAuto
-	case "true", "1", "on":
-		return CostOn
-	case "false", "0", "off":
-		return CostOff
+// Cost mode values.
+const (
+	CostAuto = modeAuto
+	CostOn   = modeOn
+	CostOff  = modeOff
+)
+
+// normalizeBoolish maps a boolean-ish value onto modeOn or modeOff. It accepts
+// every spelling strconv.ParseBool accepts — the mode options were plain bool
+// flags once, and a config or command line carrying "True" or "T" must keep
+// working — plus the on/off pair. Returns "" when the value is not boolean-ish.
+func normalizeBoolish(raw string) string {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case modeOn, "t", "1", "on":
+		return modeOn
+	case modeOff, "f", "0", "off":
+		return modeOff
 	default:
 		return ""
 	}
+}
+
+// NormalizeCostMode converts various user inputs to a canonical cost mode.
+// Accepts "auto" and any boolean-ish value. Returns "" for unknown values.
+func NormalizeCostMode(raw string) string {
+	if isAuto(raw) {
+		return CostAuto
+	}
+
+	return normalizeBoolish(raw)
+}
+
+// isAuto reports whether a mode value asks for the automatic behavior. An empty
+// value means the option was not set, which is the automatic default.
+func isAuto(raw string) bool {
+	trimmed := strings.ToLower(strings.TrimSpace(raw))
+
+	return trimmed == modeAuto || trimmed == ""
+}
+
+// Per-model quota mode values.
+const (
+	// PerModelAuto shows only the per-model window matching the selected model.
+	PerModelAuto = modeAuto
+	// PerModelAll shows every per-model window the server reports.
+	PerModelAll = modeOn
+	// PerModelOff shows no per-model windows.
+	PerModelOff = modeOff
+)
+
+// NormalizePerModelQuota converts user input to a canonical per-model quota mode.
+// Booleans are accepted in every spelling the option's former bool flag took.
+// Returns "" for unknown values.
+func NormalizePerModelQuota(raw string) string {
+	if isAuto(raw) {
+		return PerModelAuto
+	}
+
+	return normalizeBoolish(raw)
 }
 
 // Theme values selecting the statusline icon style.
@@ -68,7 +116,7 @@ type Segments struct {
 	Context       bool   `mapstructure:"context"`
 	Compactions   bool   `mapstructure:"compactions"`
 	Quota         bool   `mapstructure:"quota"`
-	PerModelQuota bool   `mapstructure:"per_model_quota"`
+	PerModelQuota string `mapstructure:"per_model_quota"`
 	Credits       bool   `mapstructure:"credits"`
 }
 
@@ -92,18 +140,19 @@ type Config struct {
 func Defaults() Config {
 	return Config{
 		Segments: Segments{
-			Model:       true,
-			Effort:      true,
-			Thinking:    true,
-			FastMode:    true,
-			Repo:        true,
-			Worktree:    true,
-			Cost:        CostAuto,
-			Status:      true,
-			Context:     true,
-			Compactions: true,
-			Quota:       true,
-			Credits:     true,
+			Model:         true,
+			Effort:        true,
+			Thinking:      true,
+			FastMode:      true,
+			Repo:          true,
+			Worktree:      true,
+			Cost:          CostAuto,
+			Status:        true,
+			Context:       true,
+			Compactions:   true,
+			Quota:         true,
+			PerModelQuota: PerModelAuto,
+			Credits:       true,
 		},
 		Cache: Cache{
 			UsageTTL:  defaultUsageTTL,
@@ -145,6 +194,14 @@ func Load(configPath string) Config {
 		fmt.Fprintf(os.Stderr, "claudeline: invalid cost mode %q, using auto\n", viperInstance.GetString("segments.cost"))
 
 		cfg.Segments.Cost = CostAuto
+	}
+
+	cfg.Segments.PerModelQuota = NormalizePerModelQuota(cfg.Segments.PerModelQuota)
+	if cfg.Segments.PerModelQuota == "" {
+		fmt.Fprintf(os.Stderr, "claudeline: invalid per-model quota mode %q, using auto\n",
+			viperInstance.GetString("segments.per_model_quota"))
+
+		cfg.Segments.PerModelQuota = PerModelAuto
 	}
 
 	cfg.Theme = NormalizeTheme(cfg.Theme)
@@ -237,6 +294,11 @@ func validateSegments(seg *Segments, v *viper.Viper) []string {
 		problems = append(problems, fmt.Sprintf("segments.cost: unknown value %q (expected auto, true, or false)", raw))
 	}
 
+	if raw := seg.PerModelQuota; NormalizePerModelQuota(raw) == "" {
+		problems = append(problems,
+			fmt.Sprintf("segments.per_model_quota: unknown value %q (expected auto, true, or false)", raw))
+	}
+
 	boolFields := []struct {
 		key string
 		raw any
@@ -251,7 +313,6 @@ func validateSegments(seg *Segments, v *viper.Viper) []string {
 		{"segments.context", v.Get("segments.context")},
 		{"segments.compactions", v.Get("segments.compactions")},
 		{"segments.quota", v.Get("segments.quota")},
-		{"segments.per_model_quota", v.Get("segments.per_model_quota")},
 		{"segments.credits", v.Get("segments.credits")},
 	}
 
@@ -300,7 +361,7 @@ func setViperDefaults(viperInstance *viper.Viper) {
 	viperInstance.SetDefault("segments.context", true)
 	viperInstance.SetDefault("segments.compactions", true)
 	viperInstance.SetDefault("segments.quota", true)
-	viperInstance.SetDefault("segments.per_model_quota", false)
+	viperInstance.SetDefault("segments.per_model_quota", PerModelAuto)
 	viperInstance.SetDefault("segments.credits", true)
 	viperInstance.SetDefault("mac_insecure", false)
 	viperInstance.SetDefault("theme", ThemeEmoji)

--- a/internal/config/permodel_test.go
+++ b/internal/config/permodel_test.go
@@ -1,0 +1,169 @@
+package config_test
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"github.com/lexfrei/claudeline/internal/config"
+)
+
+// badValue is a value no mode option accepts.
+const badValue = "nonsense"
+
+func TestNormalizePerModelQuota(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		raw  string
+		want string
+	}{
+		{"", config.PerModelAuto},
+		{"auto", config.PerModelAuto},
+		{"AUTO", config.PerModelAuto},
+		{"true", config.PerModelAll},
+		{"1", config.PerModelAll},
+		{"on", config.PerModelAll},
+		{"false", config.PerModelOff},
+		{"0", config.PerModelOff},
+		{"off", config.PerModelOff},
+		// The option was a bool flag before it was a mode, so every spelling
+		// strconv.ParseBool took must keep resolving the same way.
+		{"True", config.PerModelAll},
+		{"TRUE", config.PerModelAll},
+		{"T", config.PerModelAll},
+		{"False", config.PerModelOff},
+		{"FALSE", config.PerModelOff},
+		{"F", config.PerModelOff},
+		{badValue, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.raw, func(t *testing.T) {
+			t.Parallel()
+
+			if got := config.NormalizePerModelQuota(tt.raw); got != tt.want {
+				t.Errorf("NormalizePerModelQuota(%q) = %q, want %q", tt.raw, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDefaultsPerModelQuotaIsAuto(t *testing.T) {
+	t.Parallel()
+
+	if got := config.Defaults().Segments.PerModelQuota; got != config.PerModelAuto {
+		t.Errorf("expected per-model quota auto by default, got %q", got)
+	}
+}
+
+// A boolean per_model_quota keeps working: it predates the mode and existing
+// configs must not break.
+func TestLoadPerModelQuotaBooleanCompat(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		body string
+		want string
+	}{
+		{"legacy true", "[segments]\nper_model_quota = true\n", config.PerModelAll},
+		{"legacy false", "[segments]\nper_model_quota = false\n", config.PerModelOff},
+		{"explicit auto", "[segments]\nper_model_quota = \"auto\"\n", config.PerModelAuto},
+		{"absent", "[segments]\nquota = true\n", config.PerModelAuto},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			path := filepath.Join(t.TempDir(), "claudelinerc.toml")
+			if err := os.WriteFile(path, []byte(tt.body), 0o600); err != nil {
+				t.Fatalf("writing config: %v", err)
+			}
+
+			if got := config.Load(path).Segments.PerModelQuota; got != tt.want {
+				t.Errorf("per_model_quota = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// Cost accepted the same bool spellings before this change; keep them working.
+func TestNormalizeCostModeBoolSpellings(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		raw  string
+		want string
+	}{
+		{"True", config.CostOn},
+		{"T", config.CostOn},
+		{"False", config.CostOff},
+		{"F", config.CostOff},
+		{"AUTO", config.CostAuto},
+		{badValue, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.raw, func(t *testing.T) {
+			t.Parallel()
+
+			if got := config.NormalizeCostMode(tt.raw); got != tt.want {
+				t.Errorf("NormalizeCostMode(%q) = %q, want %q", tt.raw, got, tt.want)
+			}
+		})
+	}
+}
+
+// An invalid value in the config file must not blank the statusline: warn and
+// fall back to auto, the same way theme and cost do.
+func TestLoadInvalidPerModelQuotaFallsBackToAuto(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "claudelinerc.toml")
+	if err := os.WriteFile(path, []byte("[segments]\nper_model_quota = \"sometimes\"\n"), 0o600); err != nil {
+		t.Fatalf("writing config: %v", err)
+	}
+
+	if got := config.Load(path).Segments.PerModelQuota; got != config.PerModelAuto {
+		t.Errorf("per_model_quota = %q, want %q", got, config.PerModelAuto)
+	}
+}
+
+// The key moved out of the boolean checks into the mode check, so validate must
+// still accept the boolean form an existing config carries.
+func TestValidateAcceptsLegacyBooleanPerModelQuota(t *testing.T) {
+	t.Parallel()
+
+	for _, body := range []string{
+		"[segments]\nper_model_quota = true\n",
+		"[segments]\nper_model_quota = false\n",
+	} {
+		path := filepath.Join(t.TempDir(), "claudelinerc.toml")
+		if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+			t.Fatalf("writing config: %v", err)
+		}
+
+		if problems := config.Validate(path); len(problems) != 0 {
+			t.Errorf("expected %q to validate cleanly, got %v", body, problems)
+		}
+	}
+}
+
+func TestValidateRejectsUnknownPerModelQuota(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "claudelinerc.toml")
+	if err := os.WriteFile(path, []byte("[segments]\nper_model_quota = \"sometimes\"\n"), 0o600); err != nil {
+		t.Fatalf("writing config: %v", err)
+	}
+
+	problems := config.Validate(path)
+
+	want := `segments.per_model_quota: unknown value "sometimes" (expected auto, true, or false)`
+	if !slices.Contains(problems, want) {
+		t.Errorf("expected per_model_quota validation error, got %v", problems)
+	}
+}

--- a/internal/fmtutil/format.go
+++ b/internal/fmtutil/format.go
@@ -217,8 +217,11 @@ type ExtraUsage struct {
 
 // ExhaustedWindow contains information about which rate limit window was exhausted.
 type ExhaustedWindow struct {
-	Name    string // "5h", "7d", "7d-opus", "7d-sonnet", "7d-cowork", or "7d-oauth"
-	Minutes int    // minutes until reset
+	// Name is "5h", "7d", or a per-model label built by ScopedLabel from the
+	// bucket name the server supplied ("7d-opus", "7d-fable", …) — the set is
+	// open, since the server names the buckets.
+	Name    string
+	Minutes int // minutes until reset
 }
 
 // Data is the parsed quota usage data.
@@ -269,8 +272,9 @@ func FormatRateLimitSegment(exhausted *ExhaustedWindow) string {
 }
 
 // FindExhaustedWindow returns the most saturated active window that is exhausted.
-// When perModel is true, per-model windows (opus, sonnet, cowork, oauth) are included.
-func FindExhaustedWindow(data *Data, perModel bool) *ExhaustedWindow {
+// The account-wide windows are always considered; perModel adds the per-model
+// windows the caller decided to display, so a hidden window never names the limit.
+func FindExhaustedWindow(data *Data, perModel []ScopedWindow) *ExhaustedWindow {
 	if data == nil {
 		return nil
 	}
@@ -285,13 +289,8 @@ func FindExhaustedWindow(data *Data, perModel bool) *ExhaustedWindow {
 		{data.SevenDay, "7d"},
 	}
 
-	if perModel {
-		windows = append(windows,
-			windowEntry{data.SevenDayOpus, "7d-opus"},
-			windowEntry{data.SevenDaySonnet, "7d-sonnet"},
-			windowEntry{data.SevenDayCowork, "7d-cowork"},
-			windowEntry{data.SevenDayOAuthApps, "7d-oauth"},
-		)
+	for _, scoped := range perModel {
+		windows = append(windows, windowEntry{scoped.Window, ScopedLabel(scoped.Name)})
 	}
 
 	var best *ExhaustedWindow

--- a/internal/fmtutil/format.go
+++ b/internal/fmtutil/format.go
@@ -229,8 +229,12 @@ type Data struct {
 	SevenDaySonnet    *QuotaWindow
 	SevenDayCowork    *QuotaWindow
 	SevenDayOAuthApps *QuotaWindow
-	Extra             *ExtraUsage
-	ErrorType         string
+	// Scoped holds per-model weekly windows the server names itself (limits[]
+	// entries scoped to a model, e.g. "Fable"). Unlike the fields above these
+	// need no client change when a new model ships.
+	Scoped    []ScopedWindow
+	Extra     *ExtraUsage
+	ErrorType string
 }
 
 // FormatStaleQuotaWindow formats a window with ?% but real time and indicator.

--- a/internal/fmtutil/format_test.go
+++ b/internal/fmtutil/format_test.go
@@ -213,7 +213,7 @@ func TestFindExhaustedWindow(t *testing.T) {
 			Utilization:      99,
 			RemainingMinutes: 125,
 		},
-	}, false)
+	}, nil)
 
 	if got == nil {
 		t.Fatal("expected non-nil ExhaustedWindow")
@@ -240,7 +240,7 @@ func TestFindExhaustedWindowFiveHour(t *testing.T) {
 			Utilization:      50,
 			RemainingMinutes: 125,
 		},
-	}, false)
+	}, nil)
 
 	if got == nil {
 		t.Fatal("expected non-nil ExhaustedWindow")
@@ -265,7 +265,7 @@ func TestFindExhaustedWindowPerModel(t *testing.T) {
 		},
 	}
 
-	got := FindExhaustedWindow(data, true)
+	got := FindExhaustedWindow(data, data.PerModelWindows())
 	if got == nil {
 		t.Fatal("expected non-nil ExhaustedWindow")
 	}
@@ -274,16 +274,16 @@ func TestFindExhaustedWindowPerModel(t *testing.T) {
 		t.Errorf("Name = %q, want %q", got.Name, "7d-opus")
 	}
 
-	gotDisabled := FindExhaustedWindow(data, false)
+	gotDisabled := FindExhaustedWindow(data, nil)
 	if gotDisabled != nil {
-		t.Errorf("expected nil when perModel is false, got %+v", gotDisabled)
+		t.Errorf("expected nil when per-model windows are not displayed, got %+v", gotDisabled)
 	}
 }
 
 func TestFindExhaustedWindowNil(t *testing.T) {
 	t.Parallel()
 
-	if got := FindExhaustedWindow(nil, false); got != nil {
+	if got := FindExhaustedWindow(nil, nil); got != nil {
 		t.Error("expected nil for nil data")
 	}
 }
@@ -294,7 +294,7 @@ func TestFindExhaustedWindowNoExhausted(t *testing.T) {
 	got := FindExhaustedWindow(&Data{
 		FiveHour: &QuotaWindow{Utilization: 50, RemainingMinutes: 45},
 		SevenDay: &QuotaWindow{Utilization: 60, RemainingMinutes: 125},
-	}, false)
+	}, nil)
 
 	if got != nil {
 		t.Error("expected nil when no window is exhausted")

--- a/internal/fmtutil/scoped.go
+++ b/internal/fmtutil/scoped.go
@@ -1,39 +1,217 @@
 package fmtutil
 
-import "strings"
+import (
+	"slices"
+	"strings"
+	"unicode"
+)
 
 // ScopedWindow is a per-model quota window reported by the server with its own
 // bucket name (for example "Fable"). The server names these buckets itself, so
 // new models appear without a client change.
 type ScopedWindow struct {
 	// Name is the server-supplied bucket label, e.g. "Fable".
-	Name   string
+	Name string
+	// ID is the model id the server scoped the bucket to. It is null in every
+	// response seen so far, but when present it identifies the model exactly and
+	// beats matching on the name.
+	ID     string
 	Window *QuotaWindow
 }
 
-// normalizeModelToken lowercases a model or bucket name and collapses spaces to
-// dashes, so "Fable 5" and "claude-fable-5" become comparable.
-func normalizeModelToken(raw string) string {
-	return strings.ReplaceAll(strings.ToLower(strings.TrimSpace(raw)), " ", "-")
+// MatchesScopedModel reports whether a quota bucket belongs to the selected
+// model, preferring the server's own model id when it sends one: an id names the
+// model outright, while a display name has to be matched by token.
+//
+// The two ids are still compared by token rather than for equality, because one
+// model is written both dated and undated ("claude-sonnet-4-5" and
+// "claude-sonnet-4-5-20250929"). Equality would read those as different models
+// and drop the segment; the token match accepts the trailing build date while
+// still refusing a different version ("claude-sonnet-4"). It is tried both ways
+// round, since either side may be the dated one.
+func MatchesScopedModel(modelID, modelDisplayName string, bucket ScopedWindow) bool {
+	if bucket.ID != "" && modelID != "" {
+		return MatchesModel(modelID, "", bucket.ID) || MatchesModel(bucket.ID, "", modelID)
+	}
+
+	return MatchesModel(modelID, modelDisplayName, bucket.Name)
 }
 
+// modelTokenSeparators are the characters a model name may be split on. The
+// server writes bucket names for humans ("Claude Opus 4.5") while model ids are
+// slugs ("claude-opus-4-5"); folding both onto dashes makes them comparable.
+var modelTokenSeparators = strings.NewReplacer(" ", "-", ".", "-", "_", "-")
+
+// normalizeModelToken lowercases a model or bucket name and folds its separators
+// to dashes, so "Claude Opus 4.5" and "claude-opus-4-5" become comparable.
+func normalizeModelToken(raw string) string {
+	return modelTokenSeparators.Replace(strings.ToLower(strings.TrimSpace(raw)))
+}
+
+// versionTokenMaxLen is the greatest length at which an all-digit token still
+// reads as a version component ("4", "5", "10") rather than a build date
+// ("20250929").
+const versionTokenMaxLen = 2
+
 // MatchesModel reports whether a quota bucket belongs to the currently selected
-// model. The bucket name comes from the server ("Fable", "opus"), the model from
-// the statusline stdin ("claude-fable-5" / "Fable 5"). An empty bucket matches
-// nothing, so non-model buckets (cowork, oauth) never match a model.
+// model. The bucket name comes from the server ("Fable", "Claude Sonnet 4.5"),
+// the model from the statusline stdin ("claude-sonnet-4-5-20250929" / "Sonnet
+// 4.5"): a bucket matches when its tokens appear, in order and whole, in either.
+//
+// Whole tokens, not raw substrings, because several versions of a family are in
+// service at once and the server reports a bucket per version: "Claude Sonnet 4"
+// is a plain prefix of claude-sonnet-4-5-20250929, and letting it match would
+// show the quota of a model the session is not running. A bucket that ends on a
+// version therefore must not be followed by a further version component — while
+// a bucket naming no version at all ("sonnet") stays the family bucket and
+// matches every version of it.
+//
+// Buckets that name a surface rather than a model (cowork, oauth) never match:
+// no model is called that. An empty bucket name matches nothing.
 func MatchesModel(modelID, modelDisplayName, bucket string) bool {
-	key := normalizeModelToken(bucket)
-	if key == "" {
+	key := modelTokens(bucket)
+	if len(key) == 0 {
 		return false
 	}
 
 	for _, haystack := range []string{modelID, modelDisplayName} {
-		if strings.Contains(normalizeModelToken(haystack), key) {
+		if tokensMatch(modelTokens(haystack), key) {
 			return true
 		}
 	}
 
 	return false
+}
+
+// modelTokens splits a model or bucket name into its normalized tokens.
+func modelTokens(raw string) []string {
+	normalized := normalizeModelToken(raw)
+	if normalized == "" {
+		return nil
+	}
+
+	return strings.Split(normalized, "-")
+}
+
+// tokensMatch reports whether key occurs as a whole-token run inside haystack,
+// not continued by a further version component.
+func tokensMatch(haystack, key []string) bool {
+	for start := 0; start+len(key) <= len(haystack); start++ {
+		if !slices.Equal(haystack[start:start+len(key)], key) {
+			continue
+		}
+
+		next := start + len(key)
+		if isVersionToken(key[len(key)-1]) && next < len(haystack) && isVersionToken(haystack[next]) {
+			continue // the bucket names an older version of this model
+		}
+
+		return true
+	}
+
+	return false
+}
+
+// isVersionToken reports whether a token is a version component: all digits and
+// short enough not to be a build date.
+func isVersionToken(token string) bool {
+	if token == "" || len(token) > versionTokenMaxLen {
+		return false
+	}
+
+	return strings.IndexFunc(token, func(r rune) bool { return !unicode.IsDigit(r) }) < 0
+}
+
+// PerModelCandidates returns every per-model quota window the server reported —
+// the fixed top-level buckets first, then the server-named ones from limits[] —
+// with no collapsing. Two buckets may share a label while naming different models
+// (the family bucket "opus" and a bucket scoped to one Opus version both label
+// 7d-opus), so a caller selecting by model must filter this list, not the
+// collapsed one, or a bucket for another model could shadow the applicable one.
+func (d *Data) PerModelCandidates() []ScopedWindow {
+	// A nil Data is a legal value here — FetchLastGood returns one on a cache
+	// miss, and FindExhaustedWindow accepts it — so the pair of them being called
+	// together must not panic.
+	if d == nil {
+		return nil
+	}
+
+	topLevel := []ScopedWindow{
+		{Name: "opus", Window: d.SevenDayOpus},
+		{Name: "sonnet", Window: d.SevenDaySonnet},
+		{Name: "cowork", Window: d.SevenDayCowork},
+		{Name: "oauth", Window: d.SevenDayOAuthApps},
+	}
+
+	candidates := make([]ScopedWindow, 0, len(topLevel)+len(d.Scoped))
+
+	for _, candidate := range append(topLevel, d.Scoped...) {
+		if candidate.Window != nil {
+			candidates = append(candidates, candidate)
+		}
+	}
+
+	return candidates
+}
+
+// PerModelWindows returns the reported windows with one window per label, since a
+// label can only render once. On a collision it keeps the window closest to its
+// limit, the same rule MostBinding follows. Note this collapses labels, not
+// models: two buckets naming one model under different labels (7d-sonnet and
+// 7d-sonnet-4-5) both survive here.
+func (d *Data) PerModelWindows() []ScopedWindow {
+	candidates := d.PerModelCandidates()
+
+	windows := make([]ScopedWindow, 0, len(candidates))
+	indexByLabel := make(map[string]int, len(candidates))
+
+	for _, candidate := range candidates {
+		label := ScopedLabel(candidate.Name)
+
+		if i, collides := indexByLabel[label]; collides {
+			if candidate.Window.Utilization > windows[i].Window.Utilization {
+				windows[i] = candidate
+			}
+
+			continue
+		}
+
+		indexByLabel[label] = len(windows)
+
+		windows = append(windows, candidate)
+	}
+
+	return windows
+}
+
+// MostBinding reduces windows that all describe the same model to the one
+// closest to its limit. The server may report a model twice — a coarse family
+// bucket (seven_day_sonnet) and a finer named one ("Sonnet 4.5") — and only one
+// of them can be shown without naming the same model twice. Picking the highest
+// utilization keeps the window that will bite first: the narrower bucket usually
+// is that window, but when the family quota is the one about to run out, hiding
+// it would be exactly the wrong half to drop. Ties keep the first window, which
+// is the caller's order — top-level buckets ahead of the server-named ones.
+// Windows without data are skipped: the function is exported and takes a slice
+// the caller built, so it must not depend on their filtering.
+func MostBinding(windows []ScopedWindow) []ScopedWindow {
+	var best *ScopedWindow
+
+	for i, win := range windows {
+		if win.Window == nil {
+			continue
+		}
+
+		if best == nil || win.Window.Utilization > best.Window.Utilization {
+			best = &windows[i]
+		}
+	}
+
+	if best == nil {
+		return nil
+	}
+
+	return []ScopedWindow{*best}
 }
 
 // ScopedLabel renders the statusline label for a server-named quota bucket:

--- a/internal/fmtutil/scoped.go
+++ b/internal/fmtutil/scoped.go
@@ -1,0 +1,43 @@
+package fmtutil
+
+import "strings"
+
+// ScopedWindow is a per-model quota window reported by the server with its own
+// bucket name (for example "Fable"). The server names these buckets itself, so
+// new models appear without a client change.
+type ScopedWindow struct {
+	// Name is the server-supplied bucket label, e.g. "Fable".
+	Name   string
+	Window *QuotaWindow
+}
+
+// normalizeModelToken lowercases a model or bucket name and collapses spaces to
+// dashes, so "Fable 5" and "claude-fable-5" become comparable.
+func normalizeModelToken(raw string) string {
+	return strings.ReplaceAll(strings.ToLower(strings.TrimSpace(raw)), " ", "-")
+}
+
+// MatchesModel reports whether a quota bucket belongs to the currently selected
+// model. The bucket name comes from the server ("Fable", "opus"), the model from
+// the statusline stdin ("claude-fable-5" / "Fable 5"). An empty bucket matches
+// nothing, so non-model buckets (cowork, oauth) never match a model.
+func MatchesModel(modelID, modelDisplayName, bucket string) bool {
+	key := normalizeModelToken(bucket)
+	if key == "" {
+		return false
+	}
+
+	for _, haystack := range []string{modelID, modelDisplayName} {
+		if strings.Contains(normalizeModelToken(haystack), key) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// ScopedLabel renders the statusline label for a server-named quota bucket:
+// "Fable" becomes "7d-fable", matching the existing 7d-opus / 7d-sonnet labels.
+func ScopedLabel(bucket string) string {
+	return "7d-" + normalizeModelToken(bucket)
+}

--- a/internal/fmtutil/scoped_test.go
+++ b/internal/fmtutil/scoped_test.go
@@ -1,0 +1,76 @@
+package fmtutil_test
+
+import (
+	"testing"
+
+	"github.com/lexfrei/claudeline/internal/fmtutil"
+)
+
+const (
+	fableID          = "claude-fable-5"
+	fableDisplay     = "Fable 5"
+	fableBucket      = "Fable"
+	opusID           = "claude-opus-4-8"
+	opusDisplay      = "Opus 4.8"
+	sonnetID         = "claude-sonnet-5"
+	sonnetDisplay    = "Sonnet 5"
+	sonnetBucketName = "sonnet"
+)
+
+func TestMatchesModel(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		modelID     string
+		displayName string
+		bucket      string
+		want        bool
+	}{
+		{"fable id matches server bucket", fableID, fableDisplay, fableBucket, true},
+		{"opus id matches opus bucket", opusID, opusDisplay, "opus", true},
+		{"sonnet id matches sonnet bucket", sonnetID, sonnetDisplay, sonnetBucketName, true},
+		{"opus model does not match fable bucket", opusID, opusDisplay, fableBucket, false},
+		{"falls back to display name when id is empty", "", sonnetDisplay, sonnetBucketName, true},
+		{"empty bucket matches nothing", sonnetID, sonnetDisplay, "", false},
+		{"non-model bucket does not match", opusID, opusDisplay, "oauth", false},
+		{"multi-word bucket still matches the id", fableID, fableDisplay, fableDisplay, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := fmtutil.MatchesModel(tt.modelID, tt.displayName, tt.bucket)
+			if got != tt.want {
+				t.Errorf("MatchesModel(%q, %q, %q) = %v, want %v",
+					tt.modelID, tt.displayName, tt.bucket, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestScopedLabel(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		bucket string
+		want   string
+	}{
+		{"single word", fableBucket, "7d-fable"},
+		{"spaces become dashes", fableDisplay, "7d-fable-5"},
+		{"already lowercase", "opus", "7d-opus"},
+		{"surrounding space trimmed", " Fable ", "7d-fable"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := fmtutil.ScopedLabel(tt.bucket); got != tt.want {
+				t.Errorf("ScopedLabel(%q) = %q, want %q", tt.bucket, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/fmtutil/scoped_test.go
+++ b/internal/fmtutil/scoped_test.go
@@ -10,11 +10,16 @@ const (
 	fableID          = "claude-fable-5"
 	fableDisplay     = "Fable 5"
 	fableBucket      = "Fable"
+	fableLabel       = "7d-fable"
 	opusID           = "claude-opus-4-8"
 	opusDisplay      = "Opus 4.8"
 	sonnetID         = "claude-sonnet-5"
 	sonnetDisplay    = "Sonnet 5"
 	sonnetBucketName = "sonnet"
+	opus45Display    = "Opus 4.5"
+	sonnet45Display  = "Sonnet 4.5"
+	sonnet45ID       = "claude-sonnet-4-5"
+	sonnet45DatedID  = "claude-sonnet-4-5-20250929"
 )
 
 func TestMatchesModel(t *testing.T) {
@@ -35,6 +40,25 @@ func TestMatchesModel(t *testing.T) {
 		{"empty bucket matches nothing", sonnetID, sonnetDisplay, "", false},
 		{"non-model bucket does not match", opusID, opusDisplay, "oauth", false},
 		{"multi-word bucket still matches the id", fableID, fableDisplay, fableDisplay, true},
+		// The server writes versions with dots ("Claude Opus 4.5") while model
+		// ids use dashes ("claude-opus-4-5"); both spellings name one model.
+		{"dotted version matches a dashed id", "claude-opus-4-5", opus45Display, "Claude " + opus45Display, true},
+		{"dotted bucket matches the dotted display name", "", opus45Display, opus45Display, true},
+		// Consecutive versions of a family are served at once, so the server can
+		// report a bucket per version. A bucket naming an older version is a
+		// plain prefix of the newer model's id and must not match it, or the
+		// statusline would show the quota of a model the session is not running.
+		{
+			"older version bucket does not match a newer model", sonnet45DatedID, sonnet45Display,
+			"Claude Sonnet 4", false,
+		},
+		{
+			"matching version bucket matches a dated id", sonnet45DatedID, sonnet45Display,
+			"Claude " + sonnet45Display, true,
+		},
+		// A bucket that names no version is the family bucket: it covers every
+		// version of that family.
+		{"family bucket matches a versioned id", sonnet45ID, sonnet45Display, sonnetBucketName, true},
 	}
 
 	for _, tt := range tests {
@@ -50,6 +74,315 @@ func TestMatchesModel(t *testing.T) {
 	}
 }
 
+// The server sends scope.model.id (null today). Once it carries a value, an
+// exact id comparison is authoritative and must win over the name heuristic —
+// including when the names would have disagreed.
+func TestMatchesModelPrefersTheServerID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		modelID     string
+		bucketID    string
+		bucketName  string
+		displayName string
+		want        bool
+	}{
+		{
+			name:       "matching ids match whatever the names say",
+			modelID:    fableID,
+			bucketID:   fableID,
+			bucketName: "Something Else",
+			want:       true,
+		},
+		{
+			name:       "differing ids do not match even when the names would",
+			modelID:    sonnet45ID,
+			bucketID:   "claude-sonnet-4",
+			bucketName: sonnetBucketName,
+			want:       false,
+		},
+		{
+			name:        "an empty bucket id falls back to the name",
+			modelID:     fableID,
+			bucketID:    "",
+			bucketName:  fableBucket,
+			displayName: fableDisplay,
+			want:        true,
+		},
+		// One model is written both dated and undated. Comparing ids for equality
+		// would call these two different models and drop the segment entirely.
+		{
+			name:       "an undated bucket id matches the dated model id",
+			modelID:    sonnet45DatedID,
+			bucketID:   sonnet45ID,
+			bucketName: sonnet45Display,
+			want:       true,
+		},
+		{
+			name:       "a dated bucket id matches the undated model id",
+			modelID:    sonnet45ID,
+			bucketID:   sonnet45DatedID,
+			bucketName: sonnet45Display,
+			want:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := fmtutil.MatchesScopedModel(tt.modelID, tt.displayName,
+				fmtutil.ScopedWindow{ID: tt.bucketID, Name: tt.bucketName})
+			if got != tt.want {
+				t.Errorf("MatchesScopedModel(%q, %q, {ID: %q, Name: %q}) = %v, want %v",
+					tt.modelID, tt.displayName, tt.bucketID, tt.bucketName, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPerModelWindows(t *testing.T) {
+	t.Parallel()
+
+	win := func(util float64) *fmtutil.QuotaWindow {
+		return &fmtutil.QuotaWindow{Utilization: util, TotalMinutes: fmtutil.SevenDayWindowMinutes}
+	}
+
+	data := &fmtutil.Data{
+		SevenDayOpus:      win(10),
+		SevenDayOAuthApps: win(20),
+		Scoped: []fmtutil.ScopedWindow{
+			{Name: fableBucket, Window: win(100)},
+			// The server may report a model both as a top-level field and as a
+			// limits[] entry; it must not render twice.
+			{Name: "Opus", Window: win(10)},
+		},
+	}
+
+	got := data.PerModelWindows()
+
+	labels := make([]string, 0, len(got))
+	for _, w := range got {
+		labels = append(labels, fmtutil.ScopedLabel(w.Name))
+	}
+
+	want := []string{"7d-opus", "7d-oauth", fableLabel}
+	if len(labels) != len(want) {
+		t.Fatalf("expected windows %v, got %v", want, labels)
+	}
+
+	for i, label := range want {
+		if labels[i] != label {
+			t.Errorf("window %d = %q, want %q", i, labels[i], label)
+		}
+	}
+}
+
+// The same model can arrive twice under one label — as a top-level field and as
+// a limits[] entry. Only one of them can render, and it must be the one closest
+// to its limit, the same rule MostBinding follows: keeping the first would let a
+// green 20% window mask the 96% quota that actually binds.
+func TestPerModelWindowsLabelCollisionKeepsTheBindingWindow(t *testing.T) {
+	t.Parallel()
+
+	win := func(util float64) *fmtutil.QuotaWindow {
+		return &fmtutil.QuotaWindow{Utilization: util, TotalMinutes: fmtutil.SevenDayWindowMinutes}
+	}
+
+	tests := []struct {
+		name      string
+		topLevel  *fmtutil.QuotaWindow
+		scoped    *fmtutil.QuotaWindow
+		wantUtil  float64
+		wantCount int
+	}{
+		{"scoped bucket binds", win(20), win(96), 96, 1},
+		{"top-level bucket binds", win(96), win(20), 96, 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			data := &fmtutil.Data{
+				SevenDaySonnet: tt.topLevel,
+				Scoped:         []fmtutil.ScopedWindow{{Name: "Sonnet", Window: tt.scoped}},
+			}
+
+			got := data.PerModelWindows()
+			if len(got) != tt.wantCount {
+				t.Fatalf("expected %d window, got %+v", tt.wantCount, got)
+			}
+
+			if got[0].Window.Utilization != tt.wantUtil {
+				t.Errorf("kept the %v%% window, want the %v%% one that binds",
+					got[0].Window.Utilization, tt.wantUtil)
+			}
+		})
+	}
+}
+
+// Candidates are uncollapsed on purpose: two buckets sharing a label may name
+// different models, and a caller selecting by model has to see both to pick the
+// one that applies.
+func TestPerModelCandidatesKeepsCollidingLabels(t *testing.T) {
+	t.Parallel()
+
+	win := func(util float64) *fmtutil.QuotaWindow {
+		return &fmtutil.QuotaWindow{Utilization: util, TotalMinutes: fmtutil.SevenDayWindowMinutes}
+	}
+
+	data := &fmtutil.Data{
+		SevenDayOpus: win(20),
+		Scoped: []fmtutil.ScopedWindow{
+			{Name: "Opus", ID: "claude-opus-4-5", Window: win(96)},
+		},
+	}
+
+	got := data.PerModelCandidates()
+	if len(got) != 2 {
+		t.Fatalf("expected both colliding candidates, got %+v", got)
+	}
+
+	// The collapsed view keeps one, and that is the difference the caller relies on.
+	if collapsed := data.PerModelWindows(); len(collapsed) != 1 {
+		t.Errorf("expected the collapsed view to keep one window, got %+v", collapsed)
+	}
+}
+
+func TestPerModelCandidatesNilData(t *testing.T) {
+	t.Parallel()
+
+	var data *fmtutil.Data
+
+	if got := data.PerModelCandidates(); len(got) != 0 {
+		t.Errorf("expected no candidates, got %+v", got)
+	}
+}
+
+func TestPerModelWindowsEmpty(t *testing.T) {
+	t.Parallel()
+
+	if got := (&fmtutil.Data{}).PerModelWindows(); len(got) != 0 {
+		t.Errorf("expected no windows, got %+v", got)
+	}
+}
+
+// A cache miss yields a nil *Data, which FindExhaustedWindow accepts — so the
+// idiomatic FindExhaustedWindow(d, d.PerModelWindows()) must survive it too.
+func TestPerModelWindowsNilData(t *testing.T) {
+	t.Parallel()
+
+	var data *fmtutil.Data
+
+	if got := data.PerModelWindows(); len(got) != 0 {
+		t.Errorf("expected no windows, got %+v", got)
+	}
+
+	if got := fmtutil.FindExhaustedWindow(data, data.PerModelWindows()); got != nil {
+		t.Errorf("expected no exhausted window, got %+v", got)
+	}
+}
+
+func TestMostBinding(t *testing.T) {
+	t.Parallel()
+
+	win := func(util float64) *fmtutil.QuotaWindow {
+		return &fmtutil.QuotaWindow{Utilization: util}
+	}
+
+	tests := []struct {
+		name string
+		in   []fmtutil.ScopedWindow
+		want string
+	}{
+		{
+			// The usual case: the narrower bucket is also the one filling up.
+			name: "narrower bucket wins when it is closer to its limit",
+			in: []fmtutil.ScopedWindow{
+				{Name: sonnetBucketName, Window: win(30)},
+				{Name: sonnet45Display, Window: win(60)},
+			},
+			want: sonnet45Display,
+		},
+		{
+			// The case that rules out picking by name: dropping the family
+			// window here would hide the quota about to run out.
+			name: "family bucket wins when it is the one about to run out",
+			in: []fmtutil.ScopedWindow{
+				{Name: sonnetBucketName, Window: win(95)},
+				{Name: sonnet45Display, Window: win(30)},
+			},
+			want: sonnetBucketName,
+		},
+		{
+			name: "ties keep the first window",
+			in: []fmtutil.ScopedWindow{
+				{Name: sonnetBucketName, Window: win(50)},
+				{Name: sonnet45Display, Window: win(50)},
+			},
+			want: sonnetBucketName,
+		},
+		{
+			name: "a single window passes through",
+			in:   []fmtutil.ScopedWindow{{Name: fableBucket, Window: win(10)}},
+			want: fableBucket,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := fmtutil.MostBinding(tt.in)
+			if len(got) != 1 {
+				t.Fatalf("expected exactly one window, got %+v", got)
+			}
+
+			if got[0].Name != tt.want {
+				t.Errorf("kept %q, want %q", got[0].Name, tt.want)
+			}
+		})
+	}
+}
+
+func TestMostBindingEmpty(t *testing.T) {
+	t.Parallel()
+
+	if got := fmtutil.MostBinding(nil); len(got) != 0 {
+		t.Errorf("expected no windows, got %+v", got)
+	}
+}
+
+// MostBinding is exported and takes a caller-built slice, so a window without
+// data must be skipped rather than panic — every other window consumer guards it.
+func TestMostBindingSkipsNilWindows(t *testing.T) {
+	t.Parallel()
+
+	got := fmtutil.MostBinding([]fmtutil.ScopedWindow{
+		{Name: sonnetBucketName, Window: nil},
+		{Name: fableBucket, Window: &fmtutil.QuotaWindow{Utilization: 10}},
+	})
+
+	if len(got) != 1 || got[0].Name != fableBucket {
+		t.Errorf("expected the window carrying data, got %+v", got)
+	}
+}
+
+func TestMostBindingAllNilWindows(t *testing.T) {
+	t.Parallel()
+
+	got := fmtutil.MostBinding([]fmtutil.ScopedWindow{
+		{Name: sonnetBucketName, Window: nil},
+		{Name: fableBucket, Window: nil},
+	})
+
+	if len(got) != 0 {
+		t.Errorf("expected no windows when none carry data, got %+v", got)
+	}
+}
+
 func TestScopedLabel(t *testing.T) {
 	t.Parallel()
 
@@ -58,10 +391,10 @@ func TestScopedLabel(t *testing.T) {
 		bucket string
 		want   string
 	}{
-		{"single word", fableBucket, "7d-fable"},
+		{"single word", fableBucket, fableLabel},
 		{"spaces become dashes", fableDisplay, "7d-fable-5"},
 		{"already lowercase", "opus", "7d-opus"},
-		{"surrounding space trimmed", " Fable ", "7d-fable"},
+		{"surrounding space trimmed", " Fable ", fableLabel},
 	}
 
 	for _, tt := range tests {

--- a/internal/usage/main_test.go
+++ b/internal/usage/main_test.go
@@ -1,0 +1,53 @@
+package usage
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestMain redirects every on-disk path of the package into a temp directory for
+// the whole suite. ParseBody writes to LastGoodCachePath unconditionally, and the
+// default paths are the ones the installed statusline reads — running the tests
+// must not overwrite the cache of the statusline on the developer's machine.
+// Both test packages (usage and usage_test) link into this binary, so one
+// TestMain covers them.
+func TestMain(m *testing.M) {
+	dir, err := os.MkdirTemp("", "claudeline-usage")
+	if err != nil {
+		panic("creating temp dir for usage tests: " + err.Error())
+	}
+
+	CachePath = filepath.Join(dir, "usage-cache.json")
+	LastGoodCachePath = filepath.Join(dir, "usage-last-good.json")
+	RetryAfterPath = filepath.Join(dir, "usage-retry-after")
+	AuthFailPath = filepath.Join(dir, "usage-auth-failed")
+
+	code := m.Run()
+
+	if removeErr := os.RemoveAll(dir); removeErr != nil {
+		panic("removing temp dir for usage tests: " + removeErr.Error())
+	}
+
+	os.Exit(code)
+}
+
+// Guards the suite itself: without the redirect above, every ParseBody call in
+// these tests rewrites the real cache in /tmp, leaving the installed statusline
+// rendering test fixtures (a 2099 reset date, or no quota segments at all).
+func TestSuiteRedirectsCachePaths(t *testing.T) {
+	t.Parallel()
+
+	paths := map[string][2]string{
+		"CachePath":         {CachePath, defaultCachePath},
+		"LastGoodCachePath": {LastGoodCachePath, defaultLastGoodCachePath},
+		"RetryAfterPath":    {RetryAfterPath, defaultRetryAfterPath},
+		"AuthFailPath":      {AuthFailPath, defaultAuthFailPath},
+	}
+
+	for name, pair := range paths {
+		if actual, def := pair[0], pair[1]; actual == def {
+			t.Errorf("%s still points at the production path %q; tests would clobber the live cache", name, def)
+		}
+	}
+}

--- a/internal/usage/scoped_test.go
+++ b/internal/usage/scoped_test.go
@@ -1,0 +1,122 @@
+package usage_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/lexfrei/claudeline/internal/usage"
+)
+
+// scopedBody mirrors the shape the Anthropic usage API returns: per-model quota
+// buckets do not arrive as top-level fields but as entries in limits[] with
+// kind "weekly_scoped" and a scope.model.
+const scopedBody = `{
+  "five_hour": {"utilization": 58.0, "resets_at": "2099-01-01T00:00:00+00:00"},
+  "seven_day": {"utilization": 78.0, "resets_at": "2099-01-02T00:00:00+00:00"},
+  "limits": [
+    {"kind": "session", "group": "session", "percent": 58, "severity": "warning", "is_active": false,
+     "resets_at": "2099-01-01T00:00:00+00:00", "scope": null},
+    {"kind": "weekly_all", "group": "weekly", "percent": 78, "severity": "warning", "is_active": false,
+     "resets_at": "2099-01-02T00:00:00+00:00", "scope": null},
+    {"kind": "weekly_scoped", "group": "weekly", "percent": 100, "severity": "critical", "is_active": true,
+     "resets_at": "2099-01-02T00:00:00+00:00",
+     "scope": {"model": {"id": null, "display_name": "Fable"}, "surface": null}}
+  ]
+}`
+
+func TestParseBodyScopedWindows(t *testing.T) {
+	t.Parallel()
+
+	data, err := usage.ParseBody([]byte(scopedBody))
+	if err != nil {
+		t.Fatalf("ParseBody() error = %v", err)
+	}
+
+	if len(data.Scoped) != 1 {
+		t.Fatalf("expected 1 scoped window, got %d", len(data.Scoped))
+	}
+
+	scoped := data.Scoped[0]
+	if scoped.Name != "Fable" {
+		t.Errorf("expected bucket name Fable, got %q", scoped.Name)
+	}
+
+	if scoped.Window == nil {
+		t.Fatal("expected a parsed quota window, got nil")
+	}
+
+	if scoped.Window.Utilization != 100 {
+		t.Errorf("expected utilization 100, got %v", scoped.Window.Utilization)
+	}
+
+	want := time.Date(2099, 1, 2, 0, 0, 0, 0, time.UTC)
+	if !scoped.Window.ResetsAt.Equal(want) {
+		t.Errorf("expected resets_at %v, got %v", want, scoped.Window.ResetsAt)
+	}
+}
+
+// is_active marks a limit that is currently biting, not one that applies: the
+// account's own session and weekly limits carry false while they still have
+// headroom. A bucket must therefore render regardless of the flag — filtering on
+// it would hide every quota that is not yet exhausted.
+func TestParseBodyScopedRendersInactiveBuckets(t *testing.T) {
+	t.Parallel()
+
+	body := `{"limits": [
+	  {"kind": "weekly_scoped", "group": "weekly", "percent": 20, "severity": "normal", "is_active": false,
+	   "resets_at": "2099-01-02T00:00:00+00:00",
+	   "scope": {"model": {"display_name": "Fable"}}}
+	]}`
+
+	data, err := usage.ParseBody([]byte(body))
+	if err != nil {
+		t.Fatalf("ParseBody() error = %v", err)
+	}
+
+	if len(data.Scoped) != 1 {
+		t.Fatalf("expected the inactive bucket to survive, got %d windows", len(data.Scoped))
+	}
+
+	if data.Scoped[0].Window.Utilization != 20 {
+		t.Errorf("expected utilization 20, got %v", data.Scoped[0].Window.Utilization)
+	}
+}
+
+func TestParseBodyScopedIgnoresNonModelLimits(t *testing.T) {
+	t.Parallel()
+
+	// A bucket must carry a model and a usable name to become a segment: a
+	// surface-scoped entry has no model, an unparseable reset has no window, and
+	// a blank name would render as a bare "7d-" label.
+	body := `{"limits": [
+	  {"kind": "weekly_scoped", "group": "weekly", "percent": 10, "resets_at": "2099-01-02T00:00:00+00:00",
+	   "scope": {"model": null, "surface": {"display_name": "Cowork"}}},
+	  {"kind": "weekly_scoped", "group": "weekly", "percent": 20, "resets_at": "not-a-timestamp",
+	   "scope": {"model": {"display_name": "Broken"}}},
+	  {"kind": "weekly_scoped", "group": "weekly", "percent": 30, "resets_at": "2099-01-02T00:00:00+00:00",
+	   "scope": {"model": {"display_name": "   "}}}
+	]}`
+
+	data, err := usage.ParseBody([]byte(body))
+	if err != nil {
+		t.Fatalf("ParseBody() error = %v", err)
+	}
+
+	if len(data.Scoped) != 0 {
+		t.Errorf("expected no scoped windows, got %d: %+v", len(data.Scoped), data.Scoped)
+	}
+}
+
+func TestParseBodyWithoutLimitsArray(t *testing.T) {
+	t.Parallel()
+
+	// Older responses have no limits[] at all; parsing must stay clean.
+	data, err := usage.ParseBody([]byte(`{"five_hour": {"utilization": 10, "resets_at": "2099-01-01T00:00:00+00:00"}}`))
+	if err != nil {
+		t.Fatalf("ParseBody() error = %v", err)
+	}
+
+	if data.Scoped != nil {
+		t.Errorf("expected nil scoped windows, got %+v", data.Scoped)
+	}
+}

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/lexfrei/claudeline/internal/cache"
@@ -29,20 +30,30 @@ const (
 	authFailTTL              = 1 * time.Hour
 )
 
+// Default locations of the on-disk state. They are named so tests can assert
+// they were redirected: ParseBody writes to LastGoodCachePath on every call, so
+// a suite that left these in place would overwrite the running statusline's cache.
+const (
+	defaultCachePath         = "/tmp/claude-usage-cache.json"
+	defaultLastGoodCachePath = "/tmp/claude-usage-last-good.json"
+	defaultRetryAfterPath    = "/tmp/claude-usage-retry-after"
+	defaultAuthFailPath      = "/tmp/claude-usage-auth-failed"
+)
+
 // CacheTTL is the cache duration for usage data. Configurable at startup.
 var CacheTTL = 10 * time.Minute
 
 // CachePath is the path to the usage cache file. Replaceable for testing.
-var CachePath = "/tmp/claude-usage-cache.json"
+var CachePath = defaultCachePath
 
 // LastGoodCachePath stores the last successful API response. Replaceable for testing.
-var LastGoodCachePath = "/tmp/claude-usage-last-good.json"
+var LastGoodCachePath = defaultLastGoodCachePath
 
 // RetryAfterPath stores the retry-after deadline. Replaceable for testing.
-var RetryAfterPath = "/tmp/claude-usage-retry-after"
+var RetryAfterPath = defaultRetryAfterPath
 
 // AuthFailPath stores the token hash of the last authentication failure. Replaceable for testing.
-var AuthFailPath = "/tmp/claude-usage-auth-failed"
+var AuthFailPath = defaultAuthFailPath
 
 // HTTPGetFn is the function used for HTTP requests. Replaceable for testing.
 var HTTPGetFn httpclient.GetFn = httpclient.Get
@@ -60,7 +71,8 @@ type apiResponse struct {
 		MonthlyLimit float64 `json:"monthly_limit"` //nolint:tagliatelle // External API format
 		UsedCredits  float64 `json:"used_credits"`  //nolint:tagliatelle // External API format
 	} `json:"extra_usage"` //nolint:tagliatelle // External API format
-	Error *struct {
+	Limits []apiLimit `json:"limits"`
+	Error  *struct {
 		Type string `json:"type"`
 	} `json:"error"`
 }
@@ -69,6 +81,32 @@ type apiResponse struct {
 type apiWindow struct {
 	Utilization float64 `json:"utilization"`
 	ResetsAt    string  `json:"resets_at"` //nolint:tagliatelle // External API format
+}
+
+// kindWeeklyScoped marks a limits[] entry that applies to one scope (a model or
+// a surface) rather than the account as a whole.
+const kindWeeklyScoped = "weekly_scoped"
+
+// apiLimit is an entry of the limits[] array. Per-model quotas (Fable and any
+// future model) arrive here rather than as top-level fields, so the server can
+// add buckets without a client release.
+//
+// Two fields of an entry are deliberately ignored. severity is the server's own
+// colour, while the statusline derives colour from utilization against elapsed
+// time. is_active marks a limit that is currently biting, not one that applies:
+// live responses carry is_active false on the account's own session and weekly
+// limits while they still have headroom, and true only once a bucket is spent.
+// Skipping inactive entries would therefore hide every quota that is not yet
+// exhausted — exactly the ones worth watching.
+type apiLimit struct {
+	Kind     string  `json:"kind"`
+	Percent  float64 `json:"percent"`
+	ResetsAt string  `json:"resets_at"` //nolint:tagliatelle // External API format
+	Scope    *struct {
+		Model *struct {
+			DisplayName string `json:"display_name"` //nolint:tagliatelle // External API format
+		} `json:"model"`
+	} `json:"scope"`
 }
 
 // Fetch retrieves quota usage from Anthropic API (with caching).
@@ -228,6 +266,8 @@ func ParseBody(body []byte) (*fmtutil.Data, error) {
 		result.SevenDayOAuthApps = parseWindow(resp.SevenDayOAuthApps, fmtutil.SevenDayWindowMinutes)
 	}
 
+	result.Scoped = parseScopedWindows(resp.Limits)
+
 	if resp.ExtraUsage != nil && resp.ExtraUsage.IsEnabled && resp.ExtraUsage.UsedCredits > 0 {
 		result.Extra = &fmtutil.ExtraUsage{
 			MonthlyLimit: resp.ExtraUsage.MonthlyLimit,
@@ -236,6 +276,37 @@ func ParseBody(body []byte) (*fmtutil.Data, error) {
 	}
 
 	return result, nil
+}
+
+// parseScopedWindows extracts per-model weekly windows from the limits[] array.
+// Entries without a model scope (surface-scoped buckets) and entries whose reset
+// timestamp does not parse are skipped: neither can be rendered as a model quota.
+func parseScopedWindows(limits []apiLimit) []fmtutil.ScopedWindow {
+	var scoped []fmtutil.ScopedWindow
+
+	for _, limit := range limits {
+		if limit.Kind != kindWeeklyScoped || limit.Scope == nil || limit.Scope.Model == nil {
+			continue
+		}
+
+		// A blank name would render as a bare "7d-" label, so it is no name at all.
+		name := strings.TrimSpace(limit.Scope.Model.DisplayName)
+		if name == "" {
+			continue
+		}
+
+		win := parseWindow(&apiWindow{
+			Utilization: limit.Percent,
+			ResetsAt:    limit.ResetsAt,
+		}, fmtutil.SevenDayWindowMinutes)
+		if win == nil {
+			continue
+		}
+
+		scoped = append(scoped, fmtutil.ScopedWindow{Name: name, Window: win})
+	}
+
+	return scoped
 }
 
 func parseWindow(win *apiWindow, totalMinutes int) *fmtutil.QuotaWindow {

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -104,6 +104,9 @@ type apiLimit struct {
 	ResetsAt string  `json:"resets_at"` //nolint:tagliatelle // External API format
 	Scope    *struct {
 		Model *struct {
+			// ID is null in every response seen so far, but when the server
+			// starts sending it, it identifies the model exactly.
+			ID          string `json:"id"`
 			DisplayName string `json:"display_name"` //nolint:tagliatelle // External API format
 		} `json:"model"`
 	} `json:"scope"`
@@ -303,7 +306,11 @@ func parseScopedWindows(limits []apiLimit) []fmtutil.ScopedWindow {
 			continue
 		}
 
-		scoped = append(scoped, fmtutil.ScopedWindow{Name: name, Window: win})
+		scoped = append(scoped, fmtutil.ScopedWindow{
+			Name:   name,
+			ID:     strings.TrimSpace(limit.Scope.Model.ID),
+			Window: win,
+		})
 	}
 
 	return scoped


### PR DESCRIPTION
## What

Adds a per-model quota segment (`7d-<model>`) that follows the model in use, and reworks `per_model_quota` from an on/off toggle into a mode.

Per-model quotas are read from the usage API's `limits[]` array instead of fixed top-level fields. The server names those buckets itself, so a quota for a newly released model — Fable today — shows up without a claudeline release.

Available only under `--mac-insecure`: the statusline stdin carries just the account-wide 5-hour and 7-day windows, so per-model data has nowhere else to come from.

## Modes

`per_model_quota` is now `auto` / `true` / `false`:

- `auto` (new default) — only the window of the model in use (`7d-fable` on Fable, `7d-opus` on Opus)
- `true` — every window the API reports
- `false` — none

**Behavior change:** per-model quotas were off unless enabled; they now default to `auto`, so a `--mac-insecure` statusline gains a `7d-<model>` segment for the model in use. Set `per_model_quota = false` to restore the old behavior. Existing boolean configs (`per_model_quota = true/false`) keep working.

## Notes

- Buckets are matched to the selected model by token, so an older family version (`Claude Sonnet 4`) never shadows the running one (`claude-sonnet-4-5`); when a model is reported by more than one bucket, the one closest to its limit is shown.
- Fixes a related inconsistency where `--cost on` / `--cost 1` were silently ignored on the CLI while the config key accepted them.