### PR TITLE
chore(renovate): extend the shared preset

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "github>lexfrei/renovate-config"
   ]
 }


### PR DESCRIPTION
config:recommended does not enable automerge, so every update here waited for a human even when CI was green. Three of them are open right now with all five checks passing.

The shared preset merges minor, patch, pin and digest updates and keeps the semantic-commit shape used across the other repos.