### PR TITLE
Feat/glm zai support

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,21 @@ Set `refreshInterval` in `~/.claude/settings.json` to also re-run the command on
 }
 ```
 
+## Running Claude Code on GLM (Z.ai)
+
+When Claude Code is pointed at Z.ai's Anthropic-compatible endpoint (`ANTHROPIC_BASE_URL` on `api.z.ai`, or its Zhipu `*.bigmodel.cn` mirrors), claudeline adapts automatically — no extra flags:
+
+```text
+🤖 GLM-5.2 ⬆️💭 | 🧠 42% | 🟢 7d: 22% (3d 1h) | 🟢 5h: 18% (1h 41m) | 🌿 master
+```
+
+- **Model segment** — GLM model ids are rendered the way Z.ai spells them (`glm-5.2` → `GLM-5.2`, `glm-4.5-air` → `GLM-4.5-Air`). The harness only title-cases unknown ids (`Glm 5.2`); a genuine display name from the harness still wins.
+- **Quota segments** — stdin carries no `rate_limits` on Z.ai, so the 5-hour and weekly windows of the GLM Coding Plan are read from Z.ai's own usage API (`GET /api/monitor/usage/quota/limit`), authenticated with the same `ANTHROPIC_AUTH_TOKEN` Claude Code uses. Responses are cached like every other fetch; on failure the last good sample renders stale, and a rejected key shows `⚠️ key invalid`. The plan's monthly tool counter (web search and friends) is not a percentage window and is not rendered.
+- **Cost segment** — `auto` hides cost on Z.ai: Coding Plan sessions are quota-metered, and the harness's cost figure knows no GLM pricing. `--cost true` still forces it.
+- **Status segment** — the platform-status feed tracks Anthropic's endpoint, so it is not consulted while on Z.ai.
+
+Provider detection prefers the base URL and falls back to the model id (`glm-*`), so the Z.ai quota path works even without the env exported.
+
 ## Configuration
 
 Optional config file at `~/.claudelinerc.toml`:

--- a/cmd/claudeline/glm_test.go
+++ b/cmd/claudeline/glm_test.go
@@ -1,0 +1,252 @@
+package main
+
+import (
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/lexfrei/claudeline/internal/config"
+	"github.com/lexfrei/claudeline/internal/httpclient"
+	"github.com/lexfrei/claudeline/internal/status"
+	"github.com/lexfrei/claudeline/internal/zai"
+)
+
+// zaiBaseURL / zaiAPIKey mirror a Claude Code session pointed at Z.ai's
+// Anthropic-compatible endpoint.
+const (
+	zaiBaseURL = "https://api.z.ai/api/anthropic"
+	zaiAPIKey  = "test-zai-key"
+
+	displayGLM52 = "GLM-5.2"
+)
+
+// glmStdin is a realistic payload for a GLM session: the harness title-cases
+// unknown model ids for display_name, and carries no Anthropic rate_limits.
+// extra is spliced into the top-level object.
+func glmStdin(extra string) string {
+	return `{"model":{"id":"glm-5.2","display_name":"Glm 5.2"},
+		"effort":{"level":"high"},"thinking":{"enabled":true},` +
+		`"context_window":{"used_percentage":42.0}` + extra + `}`
+}
+
+// zaiQuotaBody carries the plan windows the monitor endpoint reports: 7% of
+// the 5-hour quota, 20% of the weekly one.
+func zaiQuotaBody(t *testing.T) []byte {
+	t.Helper()
+
+	return []byte(`{"code":200,"msg":"Operation successful","success":true,"data":{"limits":[
+		{"type":"TOKENS_LIMIT","unit":3,"number":5,"percentage":7,` +
+		`"nextResetTime":` + millis(t, 3*time.Hour) + `},
+		{"type":"TOKENS_LIMIT","unit":6,"number":1,"percentage":20,` +
+		`"nextResetTime":` + millis(t, 5*24*time.Hour) + `}
+	]},"level":"pro"}`)
+}
+
+func millis(t *testing.T, d time.Duration) string {
+	t.Helper()
+
+	return strconv.FormatInt(time.Now().Add(d).UnixMilli(), 10)
+}
+
+func TestModelDisplayNameGLM(t *testing.T) {
+	tests := []struct {
+		name string
+		id   string
+		want string
+	}{
+		{"current model", "glm-5.2", displayGLM52},
+		{"air variant", "glm-4.5-air", "GLM-4.5-Air"},
+		{"turbo variant", "glm-5-turbo", "GLM-5-Turbo"},
+		{"bare family", glmFamily, glmFamilyDisplay},
+		{"uppercase id", displayGLM52, displayGLM52},
+		{"unknown vendor still prettified", "acme-model-x", "Acme-Model-X"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := prettifyModelID(tt.id); got != tt.want {
+				t.Errorf("prettifyModelID(%q) = %q, want %q", tt.id, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestModelDisplayNamePrefersRealCatalogName(t *testing.T) {
+	cleanup := setupTestEnv(t)
+	defer cleanup()
+
+	got := buildStatusline([]byte(`{"model":{"id":"glm-5.2","display_name":"Custom Gateway Name"}}`), defaultCfg())
+	if !strings.Contains(got, "🤖 Custom Gateway Name") {
+		t.Errorf("catalog display name must win, got %q", got)
+	}
+}
+
+func TestBuildStatuslineGLMModelSegment(t *testing.T) {
+	cleanup := setupTestEnv(t)
+	defer cleanup()
+
+	status.HTTPGetFn = failHTTP
+
+	zai.HTTPGetFn = failHTTP
+
+	got := buildStatusline([]byte(glmStdin("")), defaultCfg())
+	if !strings.Contains(got, "🤖 GLM-5.2 ⬆️💭") {
+		t.Errorf("expected prettified GLM model with indicators, got %q", got)
+	}
+}
+
+func TestBuildStatuslineGLMCostAutoHidden(t *testing.T) {
+	cleanup := setupTestEnv(t)
+	defer cleanup()
+
+	t.Setenv("ANTHROPIC_BASE_URL", zaiBaseURL)
+	t.Setenv("ANTHROPIC_AUTH_TOKEN", zaiAPIKey)
+
+	zai.HTTPGetFn = func(_ string, _ map[string]string, _ time.Duration) (*httpclient.Response, error) {
+		return &httpclient.Response{StatusCode: 200, Body: zaiQuotaBody(t)}, nil
+	}
+	status.HTTPGetFn = failHTTP
+
+	const withCost = `,"cost":{"total_cost_usd":1.5}`
+
+	got := buildStatusline([]byte(glmStdin(withCost)), defaultCfg())
+	if strings.Contains(got, "💰") {
+		t.Errorf("cost auto must stay hidden on a quota-metered GLM plan, got %q", got)
+	}
+
+	forced := defaultCfg()
+	forced.Segments.Cost = config.CostOn
+
+	got = buildStatusline([]byte(glmStdin(withCost)), forced)
+	if !strings.Contains(got, "💰 $1.50") {
+		t.Errorf("cost=true must still render, got %q", got)
+	}
+}
+
+func TestBuildStatuslineZaiQuotaWindows(t *testing.T) {
+	cleanup := setupTestEnv(t)
+	defer cleanup()
+
+	t.Setenv("ANTHROPIC_BASE_URL", zaiBaseURL)
+	t.Setenv("ANTHROPIC_AUTH_TOKEN", zaiAPIKey)
+
+	zai.HTTPGetFn = func(_ string, _ map[string]string, _ time.Duration) (*httpclient.Response, error) {
+		return &httpclient.Response{StatusCode: 200, Body: zaiQuotaBody(t)}, nil
+	}
+	// The Anthropic status feed must not be consulted on the Z.ai provider.
+	status.HTTPGetFn = func(_ string, _ map[string]string, _ time.Duration) (*httpclient.Response, error) {
+		t.Error("platform status must not be fetched for a non-Anthropic provider")
+
+		return nil, nil //nolint:nilnil // unreachable
+	}
+
+	got := buildStatusline([]byte(glmStdin("")), defaultCfg())
+	for _, want := range []string{"5h: 7%", "7d: 20%"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("expected %q in Z.ai quota segments, got %q", want, got)
+		}
+	}
+}
+
+func TestBuildStatuslineZaiModelIDFallback(t *testing.T) {
+	cleanup := setupTestEnv(t)
+	defer cleanup()
+
+	// No base URL exported: the GLM model id alone must route to the Z.ai path.
+	t.Setenv("ANTHROPIC_AUTH_TOKEN", zaiAPIKey)
+
+	zai.HTTPGetFn = func(_ string, _ map[string]string, _ time.Duration) (*httpclient.Response, error) {
+		return &httpclient.Response{StatusCode: 200, Body: zaiQuotaBody(t)}, nil
+	}
+	status.HTTPGetFn = failHTTP
+
+	got := buildStatusline([]byte(glmStdin("")), defaultCfg())
+	if !strings.Contains(got, "5h: 7%") {
+		t.Errorf("model id detection must reach the Z.ai quota path, got %q", got)
+	}
+}
+
+func TestBuildStatuslineZaiFetchErrorShowsPlaceholders(t *testing.T) {
+	cleanup := setupTestEnv(t)
+	defer cleanup()
+
+	t.Setenv("ANTHROPIC_BASE_URL", zaiBaseURL)
+	t.Setenv("ANTHROPIC_AUTH_TOKEN", zaiAPIKey)
+
+	zai.HTTPGetFn = failHTTP
+	status.HTTPGetFn = failHTTP
+
+	got := buildStatusline([]byte(glmStdin("")), defaultCfg())
+	if !strings.Contains(got, "⏳ 7d: ?%") || !strings.Contains(got, "⏳ 5h: ?%") {
+		t.Errorf("fetch error without last-good must render placeholders, got %q", got)
+	}
+}
+
+func TestBuildStatuslineZaiKeyInvalid(t *testing.T) {
+	cleanup := setupTestEnv(t)
+	defer cleanup()
+
+	t.Setenv("ANTHROPIC_BASE_URL", zaiBaseURL)
+	t.Setenv("ANTHROPIC_AUTH_TOKEN", zaiAPIKey)
+
+	zai.HTTPGetFn = func(_ string, _ map[string]string, _ time.Duration) (*httpclient.Response, error) {
+		return &httpclient.Response{StatusCode: 401, Body: []byte(`{"code":401,"success":false}`)}, nil
+	}
+	status.HTTPGetFn = failHTTP
+
+	got := buildStatusline([]byte(glmStdin("")), defaultCfg())
+	if !strings.Contains(got, "⚠️ key invalid") {
+		t.Errorf("auth failure must name the key, got %q", got)
+	}
+}
+
+func TestBuildStatuslineZaiNoKeyStaysSilent(t *testing.T) {
+	cleanup := setupTestEnv(t)
+	defer cleanup()
+
+	t.Setenv("ANTHROPIC_BASE_URL", zaiBaseURL)
+
+	zai.HTTPGetFn = func(_ string, _ map[string]string, _ time.Duration) (*httpclient.Response, error) {
+		t.Error("no key configured: the monitor API must not be queried")
+
+		return nil, nil //nolint:nilnil // unreachable
+	}
+	status.HTTPGetFn = failHTTP
+
+	got := buildStatusline([]byte(glmStdin("")), defaultCfg())
+	if strings.Contains(got, "⏳") || strings.Contains(got, "5h") || strings.Contains(got, "7d") {
+		t.Errorf("keyless Z.ai session must render no quota segments, got %q", got)
+	}
+}
+
+func TestBuildStatuslineZaiStaleAfterGoodSample(t *testing.T) {
+	cleanup := setupTestEnv(t)
+	defer cleanup()
+
+	t.Setenv("ANTHROPIC_BASE_URL", zaiBaseURL)
+	t.Setenv("ANTHROPIC_AUTH_TOKEN", zaiAPIKey)
+
+	zai.HTTPGetFn = func(_ string, _ map[string]string, _ time.Duration) (*httpclient.Response, error) {
+		return &httpclient.Response{StatusCode: 200, Body: zaiQuotaBody(t)}, nil
+	}
+	status.HTTPGetFn = failHTTP
+
+	if got := buildStatusline([]byte(glmStdin("")), defaultCfg()); !strings.Contains(got, "5h: 7%") {
+		t.Fatalf("first render must show live windows, got %q", got)
+	}
+
+	// Expire the fresh response cache so the second render refetches (and
+	// fails); the last-good sample must survive to render stale windows.
+	if err := os.Remove(zai.CachePath); err != nil {
+		t.Fatalf("expiring cache: %v", err)
+	}
+
+	zai.HTTPGetFn = failHTTP
+
+	got := buildStatusline([]byte(glmStdin("")), defaultCfg())
+	if !strings.Contains(got, "5h: ?%") {
+		t.Errorf("failed refetch must degrade to stale windows, got %q", got)
+	}
+}

--- a/cmd/claudeline/main.go
+++ b/cmd/claudeline/main.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/spf13/cobra"
 
@@ -17,8 +18,10 @@ import (
 	"github.com/lexfrei/claudeline/internal/config"
 	"github.com/lexfrei/claudeline/internal/fmtutil"
 	"github.com/lexfrei/claudeline/internal/gitinfo"
+	"github.com/lexfrei/claudeline/internal/provider"
 	"github.com/lexfrei/claudeline/internal/status"
 	"github.com/lexfrei/claudeline/internal/usage"
+	"github.com/lexfrei/claudeline/internal/zai"
 )
 
 var (
@@ -204,6 +207,8 @@ func applyRuntimeConfig(cfg *config.Config) {
 	if cfg.MacInsecure {
 		usage.CacheTTL = cfg.Cache.UsageTTL
 	}
+
+	zai.CacheTTL = cfg.Cache.UsageTTL
 }
 
 func applyIdentityFlags(cmd *cobra.Command, cfg *config.Config) {
@@ -315,20 +320,51 @@ func buildStatusline(raw []byte, cfg *config.Config) string {
 		fmt.Fprintf(os.Stderr, "claudeline: stdin parse error: %v\n", unmarshalErr)
 	}
 
+	prov := activeProvider(&data)
+
 	var segments []string
 
-	segments = appendIdentitySegments(segments, &data, cfg)
-	segments = appendCostAndStatusSegments(segments, &data, cfg)
+	segments = appendIdentitySegments(segments, &data, cfg, prov)
+	segments = appendCostAndStatusSegments(segments, &data, cfg, prov)
 	segments = appendContextSegments(segments, &data, cfg)
 
 	if cfg.Segments.Quota || cfg.Segments.Credits {
-		segments = appendUsageSegments(segments, &data, cfg)
+		segments = appendUsageSegments(segments, &data, cfg, prov)
 	}
 
 	segments = appendRepoSegment(segments, &data, cfg)
 
 	return fmtutil.JoinPipeWrap(segments, wrapWidth())
 }
+
+// activeProvider decides which API provider the session runs on. The base URL
+// Claude Code is configured with (exported to the statusline process) is
+// authoritative; a GLM model id is a secondary signal for setups where that
+// env did not propagate but the model still names its vendor.
+func activeProvider(data *stdinData) provider.Provider {
+	if prov := provider.Detect(os.Getenv("ANTHROPIC_BASE_URL")); prov == provider.Zai {
+		return prov
+	}
+
+	id := strings.ToLower(data.Model.ID)
+
+	if id == glmFamily || strings.HasPrefix(id, glmFamily+"-") {
+		return provider.Zai
+	}
+
+	return provider.Anthropic
+}
+
+// glmFamily is the token naming Z.ai's model family, in id and display
+// spellings: model ids are lowercased slugs (glm-5.2), displays are capitalized.
+const (
+	glmFamily        = "glm"
+	glmFamilyDisplay = "GLM"
+)
+
+// defaultZaiRoot is the server root used when GLM was detected from the model
+// id rather than the base URL and no root can be derived.
+const defaultZaiRoot = "https://api.z.ai"
 
 // wrapWidth returns the visual width JoinPipeWrap should target.
 //
@@ -475,17 +511,84 @@ func prReviewIcon(state string) string {
 }
 
 // appendIdentitySegments adds model segment.
-func appendIdentitySegments(segments []string, data *stdinData, cfg *config.Config) []string {
+func appendIdentitySegments(segments []string, data *stdinData, cfg *config.Config, prov provider.Provider) []string {
 	if cfg.Segments.Model {
-		model := "Claude"
-		if data.Model.DisplayName != "" {
-			model = data.Model.DisplayName
-		}
+		model := modelDisplayName(data, prov)
 
 		segments = append(segments, fmtutil.Part(model, append([]string{"🤖"}, modelSubIcons(data, cfg)...)...))
 	}
 
 	return segments
+}
+
+// modelDisplayName picks the name shown in the model segment. A display name
+// the harness resolved from its model catalog is trusted as-is; one that merely
+// cosmeticizes the id is replaced — the harness title-cases unknown ids, so a
+// GLM session reports "Glm 5.2", which our prettifier renders the way the
+// vendor spells it ("GLM-5.2"). With neither id nor name the provider itself
+// names the model.
+func modelDisplayName(data *stdinData, prov provider.Provider) string {
+	if name := strings.TrimSpace(data.Model.DisplayName); name != "" && foldModelName(name) != foldModelName(data.Model.ID) {
+		return name
+	}
+
+	if id := strings.TrimSpace(data.Model.ID); id != "" {
+		return prettifyModelID(id)
+	}
+
+	if prov == provider.Zai {
+		return glmFamilyDisplay
+	}
+
+	return "Claude"
+}
+
+// nameSeparators fold onto a dash so a name and the id it was derived from
+// compare equal regardless of cosmetic spelling.
+var nameSeparators = strings.NewReplacer(" ", "-", "_", "-", ".", "-")
+
+// foldModelName lowercases a model name and folds its separators to dashes.
+func foldModelName(raw string) string {
+	return nameSeparators.Replace(strings.ToLower(strings.TrimSpace(raw)))
+}
+
+// modelAcronyms are id tokens the vendor spells in caps rather than title case.
+var modelAcronyms = map[string]string{
+	glmFamily: glmFamilyDisplay,
+}
+
+// prettifyModelID renders a model id for display: tokens split on separators,
+// known acronyms upper-cased (glm-5.2 → GLM-5.2), the rest title-cased
+// (glm-4.5-air → GLM-4.5-Air). Version and number tokens pass through since
+// they carry no letters to case.
+func prettifyModelID(id string) string {
+	tokens := strings.FieldsFunc(id, func(r rune) bool {
+		return r == '-' || r == '_' || r == ' '
+	})
+
+	for i, token := range tokens {
+		if upper, ok := modelAcronyms[strings.ToLower(token)]; ok {
+			tokens[i] = upper
+
+			continue
+		}
+
+		tokens[i] = titleCaseToken(token)
+	}
+
+	return strings.Join(tokens, "-")
+}
+
+// titleCaseToken upper-cases the first letter and lower-cases the rest.
+func titleCaseToken(token string) string {
+	if token == "" {
+		return token
+	}
+
+	runes := []rune(strings.ToLower(token))
+	runes[0] = unicode.ToUpper(runes[0])
+
+	return string(runes)
 }
 
 // modelSubIcons returns the qualifier icons shown to the right of the model
@@ -526,12 +629,18 @@ func effortIndicator(level string) string {
 }
 
 // appendCostAndStatusSegments adds cost and platform status segments.
-func appendCostAndStatusSegments(segments []string, data *stdinData, cfg *config.Config) []string {
-	if shouldShowCost(cfg.Segments.Cost, data.RateLimits.FiveHour != nil || data.RateLimits.SevenDay != nil) {
+func appendCostAndStatusSegments(segments []string, data *stdinData, cfg *config.Config, prov provider.Provider) []string {
+	// A GLM Coding Plan session is quota-metered like a subscription, and the
+	// harness's cost figure knows no GLM pricing anyway — auto hides it there.
+	isSubscriber := data.RateLimits.FiveHour != nil || data.RateLimits.SevenDay != nil || prov == provider.Zai
+
+	if shouldShowCost(cfg.Segments.Cost, isSubscriber) {
 		segments = append(segments, fmtutil.Part(fmt.Sprintf("$%.2f", data.Cost.TotalCostUSD), "💰"))
 	}
 
-	if cfg.Segments.Status {
+	// The platform-status feed tracks Anthropic's endpoint; fetching it while
+	// on another provider would report the wrong platform's health.
+	if cfg.Segments.Status && prov == provider.Anthropic {
 		if alert := status.FetchAlert(); alert != "" {
 			segments = append(segments, alert)
 		}
@@ -556,7 +665,8 @@ func appendContextSegments(segments []string, data *stdinData, cfg *config.Confi
 }
 
 // shouldShowCost determines whether to display the cost segment.
-// In "auto" mode, cost is hidden for subscribers (who have rate_limits).
+// In "auto" mode, cost is hidden for quota-metered sessions: subscribers
+// (whose stdin carries rate_limits) and GLM Coding Plan users.
 func shouldShowCost(mode string, isSubscriber bool) bool {
 	switch mode {
 	case config.CostOn:
@@ -684,12 +794,64 @@ func appendQuotaWindows(segments []string, data *fmtutil.Data, perModel []fmtuti
 	return appendWindowSegments(segments, data, perModel, fmtutil.FormatQuotaWindow)
 }
 
-func appendUsageSegments(segments []string, data *stdinData, cfg *config.Config) []string {
+func appendUsageSegments(segments []string, data *stdinData, cfg *config.Config, prov provider.Provider) []string {
 	if cfg.MacInsecure {
 		return appendInsecureUsageSegments(segments, data, cfg)
 	}
 
+	if prov == provider.Zai {
+		return appendZaiUsageSegments(segments, cfg)
+	}
+
 	return appendStdinUsageSegments(segments, data, cfg)
+}
+
+// appendZaiUsageSegments builds quota segments from the Z.ai monitor API.
+// The stdin rate_limits are an Anthropic-subscriber field and stay empty on
+// Z.ai; the plan's 5-hour and weekly windows come from the monitor endpoint
+// instead, authenticated with the same API key Claude Code itself uses. The
+// monitor reports no per-model buckets, so no selector runs on this path.
+func appendZaiUsageSegments(segments []string, cfg *config.Config) []string {
+	if !cfg.Segments.Quota {
+		return segments
+	}
+
+	key := provider.APIKey()
+	if key == "" {
+		// Provider detected but no key to query with: nothing to render, and
+		// permanent placeholders would be noise rather than information.
+		return segments
+	}
+
+	root := provider.ServerRoot(os.Getenv("ANTHROPIC_BASE_URL"))
+	if root == "" {
+		root = defaultZaiRoot
+	}
+
+	usageData, err := zai.Fetch(root, key)
+
+	// Fetch failures and monitor-endpoint throttling render last-good data: a
+	// 429 from the monitor says we asked too often, not that the plan's quota
+	// is exhausted, so no limit-hit segment is shown for it.
+	if err != nil || usageData.ErrorType == "rate_limit_error" {
+		return appendStaleZaiQuotaWindows(segments, zai.FetchLastGood())
+	}
+
+	if usageData.ErrorType == "authentication_error" {
+		return append(segments, fmtutil.Part("key invalid", "⚠️"))
+	}
+
+	return appendQuotaWindows(segments, usageData, nil)
+}
+
+// appendStaleZaiQuotaWindows renders the Z.ai last-good quota data, or
+// placeholders when no good sample was ever taken.
+func appendStaleZaiQuotaWindows(segments []string, lastGood *fmtutil.Data) []string {
+	if lastGood == nil {
+		return append(segments, fmtutil.Part("7d: ?% (?d)", "⏳"), fmtutil.Part("5h: ?% (?h)", "⏳"))
+	}
+
+	return appendWindowSegments(segments, lastGood, nil, fmtutil.FormatStaleQuotaWindow)
 }
 
 // appendStdinUsageSegments builds quota segments from stdin rate_limits (default, secure path).

--- a/cmd/claudeline/main_test.go
+++ b/cmd/claudeline/main_test.go
@@ -14,8 +14,10 @@ import (
 	"github.com/lexfrei/claudeline/internal/fmtutil"
 	"github.com/lexfrei/claudeline/internal/httpclient"
 	"github.com/lexfrei/claudeline/internal/keychain"
+	"github.com/lexfrei/claudeline/internal/provider"
 	"github.com/lexfrei/claudeline/internal/status"
 	"github.com/lexfrei/claudeline/internal/usage"
+	"github.com/lexfrei/claudeline/internal/zai"
 )
 
 const (
@@ -48,6 +50,16 @@ func setupTestEnv(t *testing.T) func() {
 	t.Setenv("COLUMNS", "sentinel")
 	os.Unsetenv("COLUMNS")
 
+	// Provider detection reads the API endpoint configuration, and quota
+	// rendering reads the API key. A developer machine running Claude Code on
+	// GLM exports both, which would silently flip these tests onto the Z.ai
+	// path — pin them to the Anthropic defaults; the GLM tests opt back in
+	// with t.Setenv.
+	for _, name := range []string{"ANTHROPIC_BASE_URL", "ANTHROPIC_AUTH_TOKEN", "ZAI_API_KEY", "GLM_API_KEY"} {
+		t.Setenv(name, "sentinel")
+		os.Unsetenv(name)
+	}
+
 	dir := t.TempDir()
 
 	origStatusPath := status.CachePath
@@ -60,12 +72,22 @@ func setupTestEnv(t *testing.T) func() {
 	origToken := keychain.GetFn
 	origStatusTTL := status.CacheTTL
 	origUsageTTL := usage.CacheTTL
+	origZaiCachePath := zai.CachePath
+	origZaiLastGoodPath := zai.LastGoodCachePath
+	origZaiRetryAfterPath := zai.RetryAfterPath
+	origZaiAuthFailPath := zai.AuthFailPath
+	origZaiHTTP := zai.HTTPGetFn
+	origZaiTTL := zai.CacheTTL
 
 	status.CachePath = filepath.Join(dir, "status-cache.json")
 	usage.CachePath = filepath.Join(dir, "usage-cache.json")
 	usage.LastGoodCachePath = filepath.Join(dir, "usage-last-good.json")
 	usage.RetryAfterPath = filepath.Join(dir, "retry-after")
 	usage.AuthFailPath = filepath.Join(dir, "auth-failed")
+	zai.CachePath = filepath.Join(dir, "zai-usage-cache.json")
+	zai.LastGoodCachePath = filepath.Join(dir, "zai-usage-last-good.json")
+	zai.RetryAfterPath = filepath.Join(dir, "zai-retry-after")
+	zai.AuthFailPath = filepath.Join(dir, "zai-auth-failed")
 
 	return func() {
 		status.CachePath = origStatusPath
@@ -78,6 +100,12 @@ func setupTestEnv(t *testing.T) func() {
 		keychain.GetFn = origToken
 		status.CacheTTL = origStatusTTL
 		usage.CacheTTL = origUsageTTL
+		zai.CachePath = origZaiCachePath
+		zai.LastGoodCachePath = origZaiLastGoodPath
+		zai.RetryAfterPath = origZaiRetryAfterPath
+		zai.AuthFailPath = origZaiAuthFailPath
+		zai.HTTPGetFn = origZaiHTTP
+		zai.CacheTTL = origZaiTTL
 	}
 }
 
@@ -1008,7 +1036,7 @@ func TestAppendUsageSegmentsLoginNeeded(t *testing.T) {
 		}, nil
 	}
 
-	segments := appendUsageSegments(nil, &stdinData{}, insecureCfg())
+	segments := appendUsageSegments(nil, &stdinData{}, insecureCfg(), provider.Anthropic)
 	joined := strings.Join(segments, " | ")
 
 	if !strings.Contains(joined, "⚠️ /login needed") {
@@ -1039,7 +1067,7 @@ func TestAppendUsageSegmentsRateLimited(t *testing.T) {
 		}, nil
 	}
 
-	segments := appendUsageSegments(nil, &stdinData{}, insecureCfg())
+	segments := appendUsageSegments(nil, &stdinData{}, insecureCfg(), provider.Anthropic)
 	joined := strings.Join(segments, " | ")
 
 	if strings.Contains(joined, "/login needed") {
@@ -1073,7 +1101,7 @@ func TestAppendUsageSegmentsSuccess(t *testing.T) {
 		}, nil
 	}
 
-	segments := appendUsageSegments(nil, &stdinData{}, insecureCfg())
+	segments := appendUsageSegments(nil, &stdinData{}, insecureCfg(), provider.Anthropic)
 	joined := strings.Join(segments, " | ")
 
 	if !strings.Contains(joined, "7d: 45%") {
@@ -1112,7 +1140,7 @@ func TestAppendUsageSegmentsPerModel(t *testing.T) {
 	cfg := insecureCfg()
 	cfg.Segments.PerModelQuota = config.PerModelAll
 
-	segments := appendUsageSegments(nil, &stdinData{}, cfg)
+	segments := appendUsageSegments(nil, &stdinData{}, cfg, provider.Anthropic)
 	joined := strings.Join(segments, " | ")
 
 	if !strings.Contains(joined, "7d: 45%") {
@@ -1136,7 +1164,7 @@ func TestAppendUsageSegmentsPerModel(t *testing.T) {
 	}
 
 	// Verify per-model windows are hidden by default.
-	segmentsDefault := appendUsageSegments(nil, &stdinData{}, insecureCfg())
+	segmentsDefault := appendUsageSegments(nil, &stdinData{}, insecureCfg(), provider.Anthropic)
 	joinedDefault := strings.Join(segmentsDefault, " | ")
 
 	if strings.Contains(joinedDefault, "7d-opus") {

--- a/cmd/claudeline/permodel_test.go
+++ b/cmd/claudeline/permodel_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/lexfrei/claudeline/internal/config"
 	"github.com/lexfrei/claudeline/internal/httpclient"
 	"github.com/lexfrei/claudeline/internal/keychain"
+	"github.com/lexfrei/claudeline/internal/provider"
 	"github.com/lexfrei/claudeline/internal/usage"
 )
 
@@ -63,7 +64,7 @@ func TestPerModelQuotaAutoShowsSelectedModelOnly(t *testing.T) {
 	cfg := insecureCfg()
 	cfg.Segments.PerModelQuota = config.PerModelAuto
 
-	joined := strings.Join(appendUsageSegments(nil, modelStdin("claude-fable-5", "Fable 5"), cfg), " | ")
+	joined := strings.Join(appendUsageSegments(nil, modelStdin("claude-fable-5", "Fable 5"), cfg, provider.Anthropic), " | ")
 
 	if !strings.Contains(joined, "7d-fable: 90%") {
 		t.Errorf("expected the Fable window while Fable is selected, got %q", joined)
@@ -87,7 +88,7 @@ func TestPerModelQuotaAutoFollowsTheModel(t *testing.T) {
 	cfg := insecureCfg()
 	cfg.Segments.PerModelQuota = config.PerModelAuto
 
-	joined := strings.Join(appendUsageSegments(nil, modelStdin("claude-opus-4-8", "Opus 4.8"), cfg), " | ")
+	joined := strings.Join(appendUsageSegments(nil, modelStdin("claude-opus-4-8", "Opus 4.8"), cfg, provider.Anthropic), " | ")
 
 	if !strings.Contains(joined, "7d-opus: 12%") {
 		t.Errorf("expected the Opus window while Opus is selected, got %q", joined)
@@ -107,7 +108,7 @@ func TestPerModelQuotaAllShowsEveryWindow(t *testing.T) {
 	cfg := insecureCfg()
 	cfg.Segments.PerModelQuota = config.PerModelAll
 
-	joined := strings.Join(appendUsageSegments(nil, modelStdin("claude-opus-4-8", "Opus 4.8"), cfg), " | ")
+	joined := strings.Join(appendUsageSegments(nil, modelStdin("claude-opus-4-8", "Opus 4.8"), cfg, provider.Anthropic), " | ")
 
 	for _, want := range []string{"7d-opus: 12%", "7d-fable: 90%"} {
 		if !strings.Contains(joined, want) {
@@ -125,7 +126,7 @@ func TestPerModelQuotaOffHidesEveryWindow(t *testing.T) {
 	cfg := insecureCfg()
 	cfg.Segments.PerModelQuota = config.PerModelOff
 
-	joined := strings.Join(appendUsageSegments(nil, modelStdin("claude-fable-5", "Fable 5"), cfg), " | ")
+	joined := strings.Join(appendUsageSegments(nil, modelStdin("claude-fable-5", "Fable 5"), cfg, provider.Anthropic), " | ")
 
 	for _, unwanted := range []string{"7d-fable", "7d-opus"} {
 		if strings.Contains(joined, unwanted) {
@@ -192,7 +193,7 @@ func TestPerModelQuotaAutoPicksTheBindingBucket(t *testing.T) {
 			cfg := insecureCfg()
 			cfg.Segments.PerModelQuota = config.PerModelAuto
 
-			joined := strings.Join(appendUsageSegments(nil, modelStdin("claude-sonnet-4-5", "Sonnet 4.5"), cfg), " | ")
+			joined := strings.Join(appendUsageSegments(nil, modelStdin("claude-sonnet-4-5", "Sonnet 4.5"), cfg, provider.Anthropic), " | ")
 
 			if !strings.Contains(joined, tt.wantSegment) {
 				t.Errorf("expected %q, got %q", tt.wantSegment, joined)
@@ -234,7 +235,7 @@ func TestPerModelQuotaAutoIgnoresOtherVersionsOfTheFamily(t *testing.T) {
 	cfg := insecureCfg()
 	cfg.Segments.PerModelQuota = config.PerModelAuto
 
-	joined := strings.Join(appendUsageSegments(nil, modelStdin("claude-sonnet-4-5-20250929", "Sonnet 4.5"), cfg), " | ")
+	joined := strings.Join(appendUsageSegments(nil, modelStdin("claude-sonnet-4-5-20250929", "Sonnet 4.5"), cfg, provider.Anthropic), " | ")
 
 	if !strings.Contains(joined, "7d-claude-sonnet-4-5: 12%") {
 		t.Errorf("expected the running model's own bucket, got %q", joined)
@@ -270,7 +271,7 @@ func TestPerModelQuotaAutoMatchesOnServerID(t *testing.T) {
 	cfg := insecureCfg()
 	cfg.Segments.PerModelQuota = config.PerModelAuto
 
-	joined := strings.Join(appendUsageSegments(nil, modelStdin("claude-fable-5", "Fable 5"), cfg), " | ")
+	joined := strings.Join(appendUsageSegments(nil, modelStdin("claude-fable-5", "Fable 5"), cfg, provider.Anthropic), " | ")
 
 	if !strings.Contains(joined, "7d-storyteller: 42%") {
 		t.Errorf("expected the bucket matched by server id, got %q", joined)
@@ -305,7 +306,7 @@ func TestPerModelQuotaAutoKeepsTheApplicableWindowOnLabelCollision(t *testing.T)
 	cfg := insecureCfg()
 	cfg.Segments.PerModelQuota = config.PerModelAuto
 
-	joined := strings.Join(appendUsageSegments(nil, modelStdin("claude-opus-4-8", "Opus 4.8"), cfg), " | ")
+	joined := strings.Join(appendUsageSegments(nil, modelStdin("claude-opus-4-8", "Opus 4.8"), cfg, provider.Anthropic), " | ")
 
 	if !strings.Contains(joined, "7d-opus: 20%") {
 		t.Errorf("expected the family window that applies to this Opus, got %q", joined)
@@ -343,7 +344,7 @@ func TestPerModelQuotaAutoMatchesDatedModelID(t *testing.T) {
 
 	stdin := modelStdin("claude-sonnet-4-5-20250929", "Sonnet 4.5")
 
-	joined := strings.Join(appendUsageSegments(nil, stdin, cfg), " | ")
+	joined := strings.Join(appendUsageSegments(nil, stdin, cfg, provider.Anthropic), " | ")
 
 	if !strings.Contains(joined, "7d-sonnet-4-5: 55%") {
 		t.Errorf("expected the dated model id to match the undated bucket id, got %q", joined)
@@ -385,7 +386,7 @@ func TestRateLimitSegmentNamesTheScopedWindow(t *testing.T) {
 	cfg := insecureCfg()
 	cfg.Segments.PerModelQuota = config.PerModelAuto
 
-	joined := strings.Join(appendUsageSegments(nil, modelStdin("claude-fable-5", "Fable 5"), cfg), " | ")
+	joined := strings.Join(appendUsageSegments(nil, modelStdin("claude-fable-5", "Fable 5"), cfg, provider.Anthropic), " | ")
 
 	if !strings.Contains(joined, "7d-fable limit hit") {
 		t.Errorf("expected the spent Fable bucket to name the limit, got %q", joined)
@@ -403,7 +404,7 @@ func TestRateLimitSegmentIgnoresHiddenWindow(t *testing.T) {
 	cfg := insecureCfg()
 	cfg.Segments.PerModelQuota = config.PerModelAuto
 
-	joined := strings.Join(appendUsageSegments(nil, modelStdin("claude-opus-4-8", "Opus 4.8"), cfg), " | ")
+	joined := strings.Join(appendUsageSegments(nil, modelStdin("claude-opus-4-8", "Opus 4.8"), cfg, provider.Anthropic), " | ")
 
 	if strings.Contains(joined, "7d-fable") {
 		t.Errorf("expected the hidden Fable bucket to stay unnamed while Opus is selected, got %q", joined)
@@ -599,7 +600,7 @@ func TestPerModelQuotaAllKeepsOverlappingBuckets(t *testing.T) {
 	cfg := insecureCfg()
 	cfg.Segments.PerModelQuota = config.PerModelAll
 
-	joined := strings.Join(appendUsageSegments(nil, modelStdin("claude-sonnet-4-5", "Sonnet 4.5"), cfg), " | ")
+	joined := strings.Join(appendUsageSegments(nil, modelStdin("claude-sonnet-4-5", "Sonnet 4.5"), cfg, provider.Anthropic), " | ")
 
 	for _, want := range []string{"7d-sonnet: 30%", "7d-sonnet-4-5: 60%"} {
 		if !strings.Contains(joined, want) {
@@ -625,7 +626,7 @@ func TestPerModelQuotaAbsentOnStdinPath(t *testing.T) {
 		ResetsAt:       float64(time.Now().Add(72 * time.Hour).Unix()),
 	}
 
-	joined := strings.Join(appendUsageSegments(nil, data, &cfg), " | ")
+	joined := strings.Join(appendUsageSegments(nil, data, &cfg, provider.Anthropic), " | ")
 
 	if strings.Contains(joined, "7d-fable") {
 		t.Errorf("expected no per-model window on the stdin path, got %q", joined)

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -1,0 +1,110 @@
+// Package provider detects which API provider Claude Code talks to, so
+// statusline segments can query the matching usage and status APIs.
+package provider
+
+import (
+	"net/url"
+	"os"
+	"strings"
+)
+
+// Provider names an API provider serving the Anthropic-compatible endpoint
+// Claude Code is configured with.
+type Provider int
+
+const (
+	// Anthropic is the default: api.anthropic.com or an unspecified base URL.
+	Anthropic Provider = iota
+	// Zai is Z.ai's GLM endpoint (with its Zhipu bigmodel.cn mirrors), which
+	// serves the Anthropic-compatible API Claude Code can run on.
+	Zai
+)
+
+// String renders the provider name for logs and diagnostics.
+func (p Provider) String() string {
+	switch p {
+	case Anthropic:
+		return nameAnthropic
+	case Zai:
+		return nameZai
+	default:
+		return nameAnthropic
+	}
+}
+
+// Provider names as rendered by String.
+const (
+	nameAnthropic = "anthropic"
+	nameZai       = "zai"
+)
+
+// zaiHosts are the servers hosting Z.ai's Anthropic-compatible API. The
+// bigmodel.cn mirrors share the account system and the monitor API shape, so
+// they are one provider from the statusline's point of view.
+func isZaiHost(host string) bool {
+	switch host {
+	case "api.z.ai", "open.bigmodel.cn", "dev.bigmodel.cn":
+		return true
+	default:
+		return strings.HasSuffix(host, ".bigmodel.cn")
+	}
+}
+
+// Detect maps an ANTHROPIC_BASE_URL value onto a provider. An empty URL means
+// the default Anthropic endpoint. Anything else is Anthropic too: unknown
+// gateways keep the historical behavior rather than guessing a quota source.
+func Detect(baseURL string) Provider {
+	if baseURL == "" {
+		return Anthropic
+	}
+
+	parsed, err := url.Parse(strings.TrimSpace(baseURL))
+	if err != nil {
+		return Anthropic
+	}
+
+	if isZaiHost(parsed.Hostname()) {
+		return Zai
+	}
+
+	return Anthropic
+}
+
+// apiPathSuffixes are the Anthropic-compatible base paths Claude Code is
+// configured with on Z.ai. The provider's own APIs (usage, monitoring) live on
+// the server root instead, so the suffix has to come off.
+var apiPathSuffixes = []string{
+	"/api/anthropic",
+	"/api/coding/paas/v4",
+	"/api/paas/v4",
+}
+
+// ServerRoot strips the known API path suffixes from a base URL, leaving the
+// root the provider's own APIs are served under:
+// "https://api.z.ai/api/anthropic" becomes "https://api.z.ai". A URL without a
+// known suffix is trimmed of its trailing slash and returned as is.
+func ServerRoot(baseURL string) string {
+	trimmed := strings.TrimRight(strings.TrimSpace(baseURL), "/")
+
+	for _, suffix := range apiPathSuffixes {
+		if root, ok := strings.CutSuffix(trimmed, suffix); ok {
+			return root
+		}
+	}
+
+	return trimmed
+}
+
+// APIKey returns the bearer key for the provider's own APIs, reading the same
+// variables Claude Code's configuration exposes to the statusline process.
+// ANTHROPIC_AUTH_TOKEN is what a Z.ai setup carries; the ZAI_API_KEY and
+// GLM_API_KEY spellings are accepted as fallbacks for setups that export them.
+func APIKey() string {
+	for _, name := range []string{"ANTHROPIC_AUTH_TOKEN", "ZAI_API_KEY", "GLM_API_KEY"} {
+		if val := os.Getenv(name); val != "" {
+			return val
+		}
+	}
+
+	return ""
+}

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -1,0 +1,81 @@
+package provider
+
+import (
+	"testing"
+)
+
+// testZaiRoot is the Z.ai server root repeated across the table.
+const testZaiRoot = "https://api.z.ai"
+
+func TestDetect(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		url  string
+		want Provider
+	}{
+		{"empty url", "", Anthropic},
+		{"default anthropic", "https://api.anthropic.com", Anthropic},
+		{"zai global", "https://api.z.ai/api/anthropic", Zai},
+		{"zai bare host", testZaiRoot, Zai},
+		{"zai coding path", "https://api.z.ai/api/coding/paas/v4", Zai},
+		{"zhipu open mirror", "https://open.bigmodel.cn/api/anthropic", Zai},
+		{"zhipu dev mirror", "https://dev.bigmodel.cn/api/coding/paas/v4", Zai},
+		{"zhipu subdomain mirror", "https://cn.bigmodel.cn/api/anthropic", Zai},
+		{"local gateway", "http://localhost:8080", Anthropic},
+		{"unparseable", "://not a url", Anthropic},
+		{"whitespace", "  https://api.z.ai/api/anthropic  ", Zai},
+		{"zai in path only", "https://proxy.example.com/api.z.ai", Anthropic},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := Detect(tt.url); got != tt.want {
+				t.Errorf("Detect(%q) = %v, want %v", tt.url, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestServerRoot(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		url  string
+		want string
+	}{
+		{"anthropic suffix", "https://api.z.ai/api/anthropic", testZaiRoot},
+		{"coding suffix", "https://api.z.ai/api/coding/paas/v4", testZaiRoot},
+		{"paas suffix", "https://open.bigmodel.cn/api/paas/v4", "https://open.bigmodel.cn"},
+		{"trailing slash", "https://api.z.ai/", testZaiRoot},
+		{"no suffix", testZaiRoot, testZaiRoot},
+		{"empty", "", ""},
+		{"unknown path kept", "https://gw.example.com/v1", "https://gw.example.com/v1"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := ServerRoot(tt.url); got != tt.want {
+				t.Errorf("ServerRoot(%q) = %q, want %q", tt.url, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestProviderString(t *testing.T) {
+	t.Parallel()
+
+	if Anthropic.String() != "anthropic" {
+		t.Errorf("Anthropic.String() = %q", Anthropic.String())
+	}
+
+	if Zai.String() != "zai" {
+		t.Errorf("Zai.String() = %q", Zai.String())
+	}
+}

--- a/internal/zai/zai.go
+++ b/internal/zai/zai.go
@@ -1,0 +1,309 @@
+// Package zai provides access to the Z.ai (GLM) coding-plan usage API.
+package zai
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/lexfrei/claudeline/internal/cache"
+	"github.com/lexfrei/claudeline/internal/fmtutil"
+	"github.com/lexfrei/claudeline/internal/httpclient"
+)
+
+// ErrUnexpectedStatus is returned when the usage API reports failure or answers
+// with a status other than 200/401/403/429.
+var ErrUnexpectedStatus = errors.New("unexpected status from z.ai usage API")
+
+const (
+	quotaLimitPath = "/api/monitor/usage/quota/limit"
+	apiTimeout     = 3 * time.Second
+
+	retryAfterBuffer         = 5 * time.Second
+	defaultRetryAfterSeconds = 30
+	authFailTTL              = 1 * time.Hour
+
+	// subDailyHorizon bounds the reset distance of a session-length window,
+	// used when a window carries no recognized unit code.
+	subDailyHorizon = 24 * time.Hour
+)
+
+// Default locations of the on-disk state. Named so tests can assert they were
+// redirected: ParseBody writes to LastGoodCachePath on every call, so a suite
+// that left these in place would overwrite the running statusline's cache.
+const (
+	defaultCachePath         = "/tmp/claudeline-zai-usage-cache.json"
+	defaultLastGoodCachePath = "/tmp/claudeline-zai-usage-last-good.json"
+	defaultRetryAfterPath    = "/tmp/claudeline-zai-usage-retry-after"
+	defaultAuthFailPath      = "/tmp/claudeline-zai-usage-auth-failed"
+)
+
+// CacheTTL is the cache duration for usage data. Configurable at startup.
+var CacheTTL = 10 * time.Minute
+
+// CachePath is the path to the usage cache file. Replaceable for testing.
+var CachePath = defaultCachePath
+
+// LastGoodCachePath stores the last successful API response. Replaceable for testing.
+var LastGoodCachePath = defaultLastGoodCachePath
+
+// RetryAfterPath stores the retry-after deadline. Replaceable for testing.
+var RetryAfterPath = defaultRetryAfterPath
+
+// AuthFailPath stores the key hash of the last authentication failure. Replaceable for testing.
+var AuthFailPath = defaultAuthFailPath
+
+// HTTPGetFn is the function used for HTTP requests. Replaceable for testing.
+var HTTPGetFn httpclient.GetFn = httpclient.Get
+
+// Limit type values. TOKENS_LIMIT entries carry the plan's percentage quota
+// windows; openusage documents CREDIT_LIMIT as a newer spelling of the same
+// entry, so both are accepted. TIME_LIMIT entries count monthly tool calls (a
+// count, not a percentage window) and are skipped.
+const (
+	limitTokens = "TOKENS_LIMIT"
+	limitCredit = "CREDIT_LIMIT"
+)
+
+// Unit codes observed in limits[] entries. The pair (unit=3, number=5) names
+// the 5-hour session window; (unit=6, number=1) names the weekly window.
+const (
+	unitHours = 3
+	unitWeeks = 6
+)
+
+// Error types reported through fmtutil.Data.ErrorType, mirroring the Anthropic
+// vocabulary the rendering layer already understands.
+const (
+	errTypeRateLimit = "rate_limit_error"
+	errTypeAuth      = "authentication_error"
+)
+
+// apiResponse mirrors the JSON envelope of the monitor API:
+//
+//	{"code":200,"msg":"Operation successful","data":{"limits":[…]},"success":true}
+type apiResponse struct {
+	Code int    `json:"code"`
+	Msg  string `json:"msg"`
+	Data *struct {
+		Limits []apiLimit `json:"limits"`
+	} `json:"data"`
+	Success bool `json:"success"`
+}
+
+// apiLimit is one entry of the limits[] array. nextResetTime is epoch
+// milliseconds; percentage is integer percent (0-100). usage/currentValue/
+// remaining are count fields used only by TIME_LIMIT entries.
+type apiLimit struct {
+	Type          string  `json:"type"`
+	Unit          int     `json:"unit"`
+	Number        int     `json:"number"`
+	Percentage    float64 `json:"percentage"`
+	NextResetTime int64   `json:"nextResetTime"`
+}
+
+// Fetch retrieves coding-plan quota usage from the Z.ai monitor API (with
+// caching). root is the server root (provider.ServerRoot of the configured
+// base URL); key the bearer API key.
+func Fetch(root, key string) (*fmtutil.Data, error) {
+	if cached, ok := cache.Read(CachePath, CacheTTL); ok {
+		return ParseBody(cached)
+	}
+
+	if retryAfterActive() {
+		return &fmtutil.Data{ErrorType: errTypeRateLimit}, nil
+	}
+
+	if key == "" {
+		return nil, fmt.Errorf("getting api key: %w", errNoAPIKey)
+	}
+
+	if authFailedForKey(key) {
+		return &fmtutil.Data{ErrorType: errTypeAuth}, nil
+	}
+
+	resp, err := HTTPGetFn(root+quotaLimitPath, map[string]string{
+		"Authorization": "Bearer " + key,
+		"Accept":        "application/json",
+	}, apiTimeout)
+	if err != nil {
+		return nil, fmt.Errorf("fetching usage: %w", err)
+	}
+
+	if resp.StatusCode == http.StatusTooManyRequests {
+		writeRetryAfter(resp.Header)
+
+		return &fmtutil.Data{ErrorType: errTypeRateLimit}, nil
+	}
+
+	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+		writeAuthFailed(key)
+
+		return &fmtutil.Data{ErrorType: errTypeAuth}, nil
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("%w: %d", ErrUnexpectedStatus, resp.StatusCode)
+	}
+
+	cache.Write(CachePath, resp.Body)
+
+	return ParseBody(resp.Body)
+}
+
+// errNoAPIKey is reported when no bearer key is configured.
+var errNoAPIKey = errors.New("no api key found")
+
+// retryAfterActive returns true if a retry-after deadline is set and has not passed.
+func retryAfterActive() bool {
+	data, ok := cache.ReadAny(RetryAfterPath)
+	if !ok {
+		return false
+	}
+
+	deadline, err := time.Parse(time.RFC3339, string(data))
+	if err != nil {
+		return false
+	}
+
+	return time.Now().UTC().Before(deadline)
+}
+
+// writeRetryAfter stores a retry-after deadline computed from the Retry-After
+// header, falling back to defaultRetryAfterSeconds when it is missing or not an
+// integer, and always adding retryAfterBuffer on top.
+func writeRetryAfter(header http.Header) {
+	seconds := defaultRetryAfterSeconds
+
+	if val := header.Get("Retry-After"); val != "" {
+		parsed, parseErr := strconv.Atoi(val)
+		if parseErr == nil {
+			seconds = max(parsed, 0)
+		}
+	}
+
+	deadline := time.Now().UTC().Add(time.Duration(seconds)*time.Second + retryAfterBuffer)
+	cache.Write(RetryAfterPath, []byte(deadline.Format(time.RFC3339)))
+}
+
+// authFailedForKey returns true if the given key received a 401/403 within authFailTTL.
+func authFailedForKey(key string) bool {
+	data, ok := cache.Read(AuthFailPath, authFailTTL)
+	if !ok {
+		return false
+	}
+
+	return string(data) == hashKey(key)
+}
+
+// writeAuthFailed stores the hash of the key that got an auth failure.
+func writeAuthFailed(key string) {
+	cache.Write(AuthFailPath, []byte(hashKey(key)))
+}
+
+// hashKey returns a hex-encoded SHA-256 hash of the key.
+func hashKey(key string) string {
+	h := sha256.Sum256([]byte(key))
+
+	return hex.EncodeToString(h[:])
+}
+
+// ParseBody parses the monitor API response body into quota windows. A
+// success:false envelope (the API answers HTTP 200 with code 500 on internal
+// misses) is an error, not empty data.
+func ParseBody(body []byte) (*fmtutil.Data, error) {
+	var resp apiResponse
+
+	unmarshalErr := json.Unmarshal(body, &resp)
+	if unmarshalErr != nil {
+		return nil, fmt.Errorf("parsing usage response: %w", unmarshalErr)
+	}
+
+	if !resp.Success || resp.Data == nil {
+		return nil, fmt.Errorf("%w: %s", ErrUnexpectedStatus, resp.Msg)
+	}
+
+	cache.Write(LastGoodCachePath, body)
+
+	result := &fmtutil.Data{}
+
+	for i := range resp.Data.Limits {
+		applyLimit(result, &resp.Data.Limits[i])
+	}
+
+	return result, nil
+}
+
+// applyLimit folds one limits[] entry into the result. Recognized TOKENS_LIMIT
+// windows land in the matching quota field with the window's full length;
+// unknown unit codes fall back to classifying by reset horizon (sub-daily →
+// five-hour, longer → seven-day) so a new window shape still renders instead of
+// silently disappearing. A field already filled by a recognized code is never
+// overwritten by the fallback.
+func applyLimit(result *fmtutil.Data, limit *apiLimit) {
+	if limit.Type != limitTokens && limit.Type != limitCredit {
+		return // TIME_LIMIT counts tool calls, not percentage windows
+	}
+
+	win := parseWindow(limit)
+	if win == nil {
+		return
+	}
+
+	switch {
+	case limit.Unit == unitHours && limit.Number == 5:
+		win.TotalMinutes = fmtutil.FiveHourWindowMinutes
+		result.FiveHour = win
+	case limit.Unit == unitWeeks && limit.Number == 1:
+		win.TotalMinutes = fmtutil.SevenDayWindowMinutes
+		result.SevenDay = win
+	default:
+		// Unknown unit code: classify by reset horizon, and only into the
+		// matching bucket — a sub-daily window must never land in SevenDay.
+		if time.Duration(win.RemainingMinutes)*time.Minute <= subDailyHorizon {
+			if result.FiveHour == nil {
+				win.TotalMinutes = fmtutil.FiveHourWindowMinutes
+				result.FiveHour = win
+			}
+		} else if result.SevenDay == nil {
+			win.TotalMinutes = fmtutil.SevenDayWindowMinutes
+			result.SevenDay = win
+		}
+	}
+}
+
+// parseWindow converts an API limit entry into a QuotaWindow. Entries whose
+// reset timestamp is absent or in the past carry no schedule and are skipped.
+func parseWindow(limit *apiLimit) *fmtutil.QuotaWindow {
+	if limit.NextResetTime <= 0 {
+		return nil
+	}
+
+	resetsAt := time.UnixMilli(limit.NextResetTime).UTC()
+
+	return &fmtutil.QuotaWindow{
+		Utilization:      limit.Percentage,
+		ResetsAt:         resetsAt,
+		RemainingMinutes: max(int(time.Until(resetsAt).Minutes()), 0),
+	}
+}
+
+// FetchLastGood returns the last successful usage data (no TTL).
+func FetchLastGood() *fmtutil.Data {
+	body, ok := cache.ReadAny(LastGoodCachePath)
+	if !ok {
+		return nil
+	}
+
+	data, err := ParseBody(body)
+	if err != nil || data.ErrorType != "" {
+		return nil
+	}
+
+	return data
+}

--- a/internal/zai/zai_test.go
+++ b/internal/zai/zai_test.go
@@ -1,0 +1,435 @@
+package zai
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/lexfrei/claudeline/internal/httpclient"
+)
+
+// suitePaths holds the suite-wide redirected paths so per-test cleanups can
+// restore them without ever pointing back at the production locations.
+var suitePaths struct {
+	cache, lastGood, retryAfter, authFail string
+}
+
+// TestMain redirects every on-disk path of the package into a temp directory
+// for the whole suite, mirroring the usage package: ParseBody writes to
+// LastGoodCachePath unconditionally, and the default paths are the ones the
+// installed statusline reads.
+func TestMain(m *testing.M) {
+	dir, err := os.MkdirTemp("", "claudeline-zai")
+	if err != nil {
+		panic("creating temp dir for zai tests: " + err.Error())
+	}
+
+	CachePath = filepath.Join(dir, "usage-cache.json")
+	LastGoodCachePath = filepath.Join(dir, "usage-last-good.json")
+	RetryAfterPath = filepath.Join(dir, "usage-retry-after")
+	AuthFailPath = filepath.Join(dir, "usage-auth-failed")
+	suitePaths.cache, suitePaths.lastGood = CachePath, LastGoodCachePath
+	suitePaths.retryAfter, suitePaths.authFail = RetryAfterPath, AuthFailPath
+
+	code := m.Run()
+
+	if removeErr := os.RemoveAll(dir); removeErr != nil {
+		panic("removing temp dir for zai tests: " + removeErr.Error())
+	}
+
+	os.Exit(code)
+}
+
+// Guards the suite itself: without the redirect above, every ParseBody call in
+// these tests rewrites the real cache in /tmp, leaving the installed statusline
+// rendering test fixtures.
+func TestSuiteRedirectsCachePaths(t *testing.T) {
+	t.Parallel()
+
+	paths := map[string][2]string{
+		"CachePath":         {CachePath, defaultCachePath},
+		"LastGoodCachePath": {LastGoodCachePath, defaultLastGoodCachePath},
+		"RetryAfterPath":    {RetryAfterPath, defaultRetryAfterPath},
+		"AuthFailPath":      {AuthFailPath, defaultAuthFailPath},
+	}
+
+	for name, pair := range paths {
+		if actual, def := pair[0], pair[1]; actual == def {
+			t.Errorf("%s still points at the production path %q; tests would clobber the live cache", name, def)
+		}
+	}
+}
+
+// liveCapture is the monitor API response captured from a real GLM Coding Plan
+// account (values unchanged; the endpoint answers GETs without echoing the
+// key). It carries all three entry kinds: the monthly TIME_LIMIT tool counter,
+// the 5-hour TOKENS_LIMIT window, and the weekly one.
+func liveCapture(resetFiveHour, resetWeekly, resetMonthly int64) []byte {
+	return []byte(`{
+		"code": 200,
+		"msg": "Operation successful",
+		"data": {
+			"limits": [
+				{"type": "TIME_LIMIT", "unit": 5, "number": 1, "usage": 1000, "currentValue": 8,
+				 "remaining": 992, "percentage": 1, "nextResetTime": ` + strconv.FormatInt(resetMonthly, 10) + `,
+				 "usageDetails": [{"modelCode": "search-prime", "usage": 8}]},
+				{"type": "TOKENS_LIMIT", "unit": 3, "number": 5, "percentage": 7, "nextResetTime": ` + strconv.FormatInt(resetFiveHour, 10) + `},
+				{"type": "TOKENS_LIMIT", "unit": 6, "number": 1, "percentage": 20, "nextResetTime": ` + strconv.FormatInt(resetWeekly, 10) + `}
+			],
+			"level": "pro"
+		},
+		"success": true
+	}`)
+}
+
+// captureTimes returns reset timestamps the given distances from now, as epoch
+// milliseconds.
+func captureTimes(t *testing.T, fiveHour, weekly time.Duration) (int64, int64) {
+	t.Helper()
+
+	now := time.Now()
+
+	return now.Add(fiveHour).UnixMilli(), now.Add(weekly).UnixMilli()
+}
+
+func TestParseBodyLiveCapture(t *testing.T) {
+	t.Parallel()
+
+	resetFiveHour, resetWeekly := captureTimes(t, 3*time.Hour, 5*24*time.Hour)
+
+	data, err := ParseBody(liveCapture(resetFiveHour, resetWeekly, time.Now().Add(720*time.Hour).UnixMilli()))
+	if err != nil {
+		t.Fatalf("ParseBody failed: %v", err)
+	}
+
+	if data.FiveHour == nil {
+		t.Fatal("expected FiveHour to be set from the unit=3/number=5 window")
+	}
+
+	if data.SevenDay == nil {
+		t.Fatal("expected SevenDay to be set from the unit=6/number=1 window")
+	}
+
+	if got := int(data.FiveHour.Utilization + 0.5); got != 7 {
+		t.Errorf("FiveHour utilization = %d, want 7", got)
+	}
+
+	if data.FiveHour.TotalMinutes != 300 {
+		t.Errorf("FiveHour TotalMinutes = %d, want 300", data.FiveHour.TotalMinutes)
+	}
+
+	if got := int(data.SevenDay.Utilization + 0.5); got != 20 {
+		t.Errorf("SevenDay utilization = %d, want 20", got)
+	}
+
+	if data.SevenDay.TotalMinutes != 10080 {
+		t.Errorf("SevenDay TotalMinutes = %d, want 10080", data.SevenDay.TotalMinutes)
+	}
+
+	if want := time.UnixMilli(resetFiveHour).UTC(); !data.FiveHour.ResetsAt.Equal(want) {
+		t.Errorf("FiveHour ResetsAt = %v, want %v", data.FiveHour.ResetsAt, want)
+	}
+
+	if data.ErrorType != "" {
+		t.Errorf("ErrorType = %q, want empty", data.ErrorType)
+	}
+}
+
+func TestParseBodyEnvelopeError(t *testing.T) {
+	t.Parallel()
+
+	// The monitor API answers HTTP 200 with code 500 / success:false on
+	// internal misses (observed on /api/coding/usage); that is an error.
+	data, err := ParseBody([]byte(`{"code":500,"msg":"404 NOT_FOUND","success":false}`))
+	if err == nil {
+		t.Fatalf("expected error, got data %+v", data)
+	}
+}
+
+func TestParseBodyUnknownUnitFallsBackToHorizon(t *testing.T) {
+	t.Parallel()
+
+	subDaily := time.Now().Add(4 * time.Hour).UnixMilli()
+	multiDay := time.Now().Add(6 * 24 * time.Hour).UnixMilli()
+
+	body := []byte(`{"code":200,"msg":"ok","success":true,"data":{"limits":[
+		{"type": "TOKENS_LIMIT", "unit": 99, "number": 1, "percentage": 42, "nextResetTime": ` + strconv.FormatInt(subDaily, 10) + `},
+		{"type": "CREDIT_LIMIT", "unit": 99, "number": 2, "percentage": 60, "nextResetTime": ` + strconv.FormatInt(multiDay, 10) + `}
+	]}}`)
+
+	data, err := ParseBody(body)
+	if err != nil {
+		t.Fatalf("ParseBody failed: %v", err)
+	}
+
+	if data.FiveHour == nil {
+		t.Fatal("expected sub-daily unknown window to land in FiveHour")
+	}
+
+	if got := int(data.FiveHour.Utilization + 0.5); got != 42 {
+		t.Errorf("FiveHour utilization = %d, want 42", got)
+	}
+
+	if data.SevenDay == nil {
+		t.Fatal("expected multi-day unknown window to land in SevenDay")
+	}
+
+	if got := int(data.SevenDay.Utilization + 0.5); got != 60 {
+		t.Errorf("SevenDay utilization = %d, want 60", got)
+	}
+
+	if data.SevenDay.TotalMinutes != 10080 {
+		t.Errorf("SevenDay TotalMinutes = %d, want 10080", data.SevenDay.TotalMinutes)
+	}
+}
+
+func TestParseBodySubDailyNeverLandsInSevenDay(t *testing.T) {
+	t.Parallel()
+
+	first := time.Now().Add(3 * time.Hour).UnixMilli()
+	second := time.Now().Add(4 * time.Hour).UnixMilli()
+
+	body := []byte(`{"code":200,"msg":"ok","success":true,"data":{"limits":[
+		{"type": "TOKENS_LIMIT", "unit": 3, "number": 5, "percentage": 7, "nextResetTime": ` + strconv.FormatInt(first, 10) + `},
+		{"type": "TOKENS_LIMIT", "unit": 99, "number": 1, "percentage": 42, "nextResetTime": ` + strconv.FormatInt(second, 10) + `}
+	]}}`)
+
+	data, err := ParseBody(body)
+	if err != nil {
+		t.Fatalf("ParseBody failed: %v", err)
+	}
+
+	if got := int(data.FiveHour.Utilization + 0.5); got != 7 {
+		t.Errorf("recognized window must win FiveHour, got %d", got)
+	}
+
+	if data.SevenDay != nil {
+		t.Errorf("sub-daily fallback window leaked into SevenDay: %+v", data.SevenDay)
+	}
+}
+
+func TestParseBodySkipsTimeLimitAndMissingResets(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`{"code":200,"msg":"ok","success":true,"data":{"limits":[
+		{"type": "TIME_LIMIT", "unit": 5, "number": 1, "usage": 1000, "percentage": 1},
+		{"type": "TOKENS_LIMIT", "unit": 3, "number": 5, "percentage": 7}
+	]}}`)
+
+	data, err := ParseBody(body)
+	if err != nil {
+		t.Fatalf("ParseBody failed: %v", err)
+	}
+
+	if data.FiveHour != nil {
+		t.Error("entry without reset time must be skipped")
+	}
+
+	if data.SevenDay != nil {
+		t.Error("TIME_LIMIT entry must not become a quota window")
+	}
+}
+
+// redirectPaths points the package's on-disk state at a private directory for
+// one test. Tests using it must not run in parallel: they mutate the globals
+// every other test reads.
+func redirectPaths(t *testing.T) {
+	t.Helper()
+
+	dir := t.TempDir()
+	CachePath = filepath.Join(dir, "cache.json")
+	LastGoodCachePath = filepath.Join(dir, "last-good.json")
+	RetryAfterPath = filepath.Join(dir, "retry-after")
+	AuthFailPath = filepath.Join(dir, "auth-failed")
+
+	t.Cleanup(restoreDefaultPaths)
+}
+
+func stubHTTP(t *testing.T, fn httpclient.GetFn) {
+	t.Helper()
+
+	HTTPGetFn = fn
+
+	t.Cleanup(restoreHTTPGet)
+}
+
+func TestFetchCachesResponse(t *testing.T) {
+	redirectPaths(t)
+
+	resetFiveHour, resetWeekly := captureTimes(t, 3*time.Hour, 5*24*time.Hour)
+
+	calls := 0
+
+	stubHTTP(t, func(_ string, _ map[string]string, _ time.Duration) (*httpclient.Response, error) {
+		calls++
+
+		return &httpclient.Response{StatusCode: 200, Body: liveCapture(resetFiveHour, resetWeekly, 0)}, nil
+	})
+
+	for range 2 {
+		data, err := Fetch("https://api.z.ai", "key")
+		if err != nil {
+			t.Fatalf("Fetch failed: %v", err)
+		}
+
+		if data.FiveHour == nil {
+			t.Fatal("expected FiveHour from fetch")
+		}
+	}
+
+	if calls != 1 {
+		t.Errorf("HTTP calls = %d, want 1 (second fetch must hit the cache)", calls)
+	}
+}
+
+func TestFetchAuthFailureIsCached(t *testing.T) {
+	redirectPaths(t)
+
+	calls := 0
+
+	stubHTTP(t, func(_ string, _ map[string]string, _ time.Duration) (*httpclient.Response, error) {
+		calls++
+
+		return &httpclient.Response{StatusCode: 401, Body: []byte(`{"code":401,"success":false}`)}, nil
+	})
+
+	for range 2 {
+		data, err := Fetch("https://api.z.ai", "key")
+		if err != nil {
+			t.Fatalf("Fetch failed: %v", err)
+		}
+
+		if data.ErrorType != errTypeAuth {
+			t.Errorf("ErrorType = %q, want authentication_error", data.ErrorType)
+		}
+	}
+
+	if calls != 1 {
+		t.Errorf("HTTP calls = %d, want 1 (auth failure must be cached for the TTL)", calls)
+	}
+}
+
+func TestFetchRateLimited(t *testing.T) {
+	redirectPaths(t)
+
+	stubHTTP(t, func(_ string, _ map[string]string, _ time.Duration) (*httpclient.Response, error) {
+		return &httpclient.Response{
+			StatusCode: 429,
+			Header:     map[string][]string{"Retry-After": {"60"}},
+		}, nil
+	})
+
+	data, err := Fetch("https://api.z.ai", "key")
+	if err != nil {
+		t.Fatalf("Fetch failed: %v", err)
+	}
+
+	if data.ErrorType != errTypeRateLimit {
+		t.Errorf("ErrorType = %q, want rate_limit_error", data.ErrorType)
+	}
+
+	// The retry-after deadline must gate the next call without hitting the API.
+	stubHTTP(t, func(_ string, _ map[string]string, _ time.Duration) (*httpclient.Response, error) {
+		t.Error("fetch during retry-after window must not reach the API")
+
+		return nil, nil //nolint:nilnil // unreachable
+	})
+
+	data, err = Fetch("https://api.z.ai", "key")
+	if err != nil {
+		t.Fatalf("Fetch failed: %v", err)
+	}
+
+	if data.ErrorType != errTypeRateLimit {
+		t.Errorf("ErrorType = %q, want rate_limit_error", data.ErrorType)
+	}
+}
+
+func TestFetchRequestShape(t *testing.T) {
+	redirectPaths(t)
+
+	var gotURL, gotAuth string
+
+	stubHTTP(t, func(url string, headers map[string]string, _ time.Duration) (*httpclient.Response, error) {
+		gotURL = url
+		gotAuth = headers["Authorization"]
+
+		return &httpclient.Response{StatusCode: 200, Body: liveCapture(0, 0, 0)}, nil
+	})
+
+	if _, err := Fetch("https://api.z.ai", "test-key"); err != nil {
+		t.Fatalf("Fetch failed: %v", err)
+	}
+
+	if want := "https://api.z.ai" + quotaLimitPath; gotURL != want {
+		t.Errorf("request URL = %q, want %q", gotURL, want)
+	}
+
+	if gotAuth != "Bearer test-key" {
+		t.Errorf("Authorization = %q, want %q", gotAuth, "Bearer test-key")
+	}
+}
+
+func TestFetchNoAPIKey(t *testing.T) {
+	redirectPaths(t)
+
+	stubHTTP(t, func(_ string, _ map[string]string, _ time.Duration) (*httpclient.Response, error) {
+		t.Error("fetch without a key must not reach the API")
+
+		return nil, nil //nolint:nilnil // unreachable
+	})
+
+	if _, err := Fetch("https://api.z.ai", ""); err == nil {
+		t.Error("expected error for empty key")
+	}
+}
+
+func TestFetchLastGood(t *testing.T) {
+	redirectPaths(t)
+
+	if data := FetchLastGood(); data != nil {
+		t.Fatalf("FetchLastGood on missing cache = %+v, want nil", data)
+	}
+
+	resetFiveHour, resetWeekly := captureTimes(t, 3*time.Hour, 5*24*time.Hour)
+
+	if _, err := ParseBody(liveCapture(resetFiveHour, resetWeekly, 0)); err != nil {
+		t.Fatalf("ParseBody failed: %v", err)
+	}
+
+	data := FetchLastGood()
+	if data == nil {
+		t.Fatal("expected last-good data after a successful parse")
+	}
+
+	if data.FiveHour == nil || data.SevenDay == nil {
+		t.Error("last-good data lost its windows")
+	}
+}
+
+func TestFetchUnexpectedStatus(t *testing.T) {
+	redirectPaths(t)
+
+	stubHTTP(t, func(_ string, _ map[string]string, _ time.Duration) (*httpclient.Response, error) {
+		return &httpclient.Response{StatusCode: 500, Body: []byte("boom")}, nil
+	})
+
+	if _, err := Fetch("https://api.z.ai", "key"); err == nil {
+		t.Error("expected error for HTTP 500")
+	}
+}
+
+// restoreDefaultPaths restores the suite-wide redirected paths (never the
+// production ones) after a test pointed them at its own directory.
+func restoreDefaultPaths() {
+	CachePath = suitePaths.cache
+	LastGoodCachePath = suitePaths.lastGood
+	RetryAfterPath = suitePaths.retryAfter
+	AuthFailPath = suitePaths.authFail
+}
+
+func restoreHTTPGet() {
+	HTTPGetFn = httpclient.Get
+}


### PR DESCRIPTION
## What's New

  Claude Code can run on GLM models via Z.ai's Anthropic-compatible endpoint (`ANTHROPIC_BASE_URL=https://api.z.ai/api/anthropic`). claudeline now detects this and adapts automatically — no flags or config needed:

  - **Model segment** — GLM ids render the way Z.ai spells them (`glm-5.2` → `GLM-5.2`, `glm-4.5-air` → `GLM-4.5-Air`). The harness only title-cases unknown ids (`Glm 5.2`); a real catalog display name still wins.
  - **Quota segments** — stdin carries no `rate_limits` on Z.ai, so the GLM Coding Plan's 5-hour and weekly windows are fetched from Z.ai's monitor API (`GET /api/monitor/usage/quota/limit`) using the same `ANTHROPIC_AUTH_TOKEN` Claude Code uses. Caching, last-good stale rendering, and retry-after handling mirror the existing usage package. Zhipu `*.bigmodel.cn` mirrors are detected too.
  - **Cost segment** — `auto` hides cost on Z.ai: plan sessions are quota-metered and the harness's cost figure knows no GLM pricing. `--cost true` still forces it.
  - **Status segment** — the Anthropic platform-status feed is not consulted while on another provider.

  Detection prefers the base URL and falls back to the model id (`glm-*`), so the quota path works even without the env exported. Everything else is unchanged; Anthropic sessions behave exactly as before.

  Example output:
      🤖 GLM-5.2 ⬆️ 💭 | 🧠 42% | 🟢 7d: 22% (3d 1h) | 🟢 5h: 18% (1h 41m) | 🌿 master

  ## Implementation

  - New `internal/provider`: provider detection, server-root derivation, API key lookup
  - New `internal/zai`: monitor-API client mapping `TOKENS_LIMIT` windows onto the existing 5h/7d renderers, with reset-horizon fallback for unknown unit codes
  - `cmd/claudeline`: provider-aware model/cost/status/quota segments
  - Tests use the captured live API response as a fixture and pin the provider env so the suite stays deterministic on GLM-configured machines