### PR TITLE
test(statusline): pin the 2.1.257 stdin payload fields

### DIFF
--- a/cmd/claudeline/harness_drift_test.go
+++ b/cmd/claudeline/harness_drift_test.go
@@ -32,7 +32,7 @@ const payloadMarker = "five_hour:{used_percentage"
 var errPayloadNotFound = errors.New("statusline payload literal not found in harness binary")
 
 // knownHarnessPayloadFields pins the snake_case field names of the statusline
-// stdin payload as of Claude Code 2.1.226. On mismatch, re-verify the schema
+// stdin payload as of Claude Code 2.1.257. On mismatch, re-verify the schema
 // against cmd/claudeline/main.go's stdinData (new fields may deserve a
 // segment; renames need a parser change), then update this list.
 func knownHarnessPayloadFields() []string {
@@ -73,9 +73,11 @@ func knownHarnessPayloadFields() []string {
 		"repo",
 		"resets_at",
 		"review_state",
+		"scratchpad_dir",
 		"session_id",
 		"session_name",
 		"seven_day",
+		"spend_limit",
 		"thinking",
 		"total_api_duration_ms",
 		"total_cost_usd",


### PR DESCRIPTION
`go test ./...` fails on a machine with Claude Code 2.1.257 installed: the drift test sees two new stdin fields.

`rate_limits.spend_limit` comes only behind a Claude apps gateway with a spend limit (since 2.1.251), same shape as `five_hour`/`seven_day`. `scratchpad_dir` is a flag-gated path, not documented.

This only pins both names. Neither is parsed: Pro/Max payloads never carry `spend_limit`, and a scratchpad path has no place in a status line. Showing `spend_limit` as a third window: #42.
